### PR TITLE
Remove prettier\prettier Delete 'CR' Error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,6 +78,11 @@ module.exports = {
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
 
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        'endOfLine': 'auto',
+      }
+    ]
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,11 +78,6 @@ module.exports = {
     // allow debugger during development only
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
 
-    "prettier/prettier": [
-      "error",
-      {
-        'endOfLine': 'auto',
-      }
-    ]
+    "prettier/prettier": "error"
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "semi": true,
-  "trailingComma": "none"  
+  "trailingComma": "none",
+  "endOfLine":"auto"  
 }


### PR DESCRIPTION
Resolve Prettier error of 'cr' that appeared when running on a windows machine.

Saw errors on pulling OBE, updating eslint for auto handling line endings.

![image](https://user-images.githubusercontent.com/1005054/150244264-afbb79ad-c741-4610-9025-6d9c481f50d6.png)
