### PR TITLE
Bugfix/issue 44, 45, 54 

### DIFF
--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -1,7 +1,12 @@
+/**
+ * Reference for Hyperion endpoints:
+ * https://rpc1.us.telos.net/v2/docs/static/index.html#/ (main net)
+ * https://testnet.telos.net/v2/docs/static/index.html#/ (testnet)
+ */
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* Reference for Hyperion endpoints: https://rpc1.us.telos.net/v2/docs/static/index.html#/ */
 import axios from 'axios';
 import { ActionData, Action, AccountDetails, Token } from 'src/types';
 

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -4,8 +4,9 @@
     q-card-section
       .inline-section
         .text-h6 {{ account }}
-        .text-subtitle created by 
-          router-link( :to="{ path: 'account', params: { account: creatingAccount}}") {{ creatingAccount }}
+        .text-subtitle(v-if="creatingAccount !== '__self__'") created by 
+          a.creator-link( @click='loadCreatorAccount') {{ creatingAccount }} 
+        q-space
       .resources.inline-section
         .resource.inline-section CPU {{ cpu }}% used
         .resource.inline-section NET {{ net }}% used
@@ -126,13 +127,23 @@ export default defineComponent({
     },
     formatResourcePercent(used: number, total: number): string {
       return ((used / total) * HUNDRED).toFixed(2);
+    },
+    async loadCreatorAccount(): Promise<void> {
+      await this.$router.push({
+        name: 'account',
+        params: {
+          account: this.creatingAccount
+        }
+      });
+      this.$router.go(0);
     }
   }
 });
 </script>
 <style lang="sass" scoped>
 $medium:750px
-
+.q-markup-table
+  width: 100%
 .account-card
   max-width: 100%
 .table-body
@@ -152,10 +163,10 @@ $medium:750px
 .text-subtitle
   font-size: 12px
   a
+    cursor: pointer
     text-decoration: none
     &:hover
       text-decoration: underline
-
 
 @media screen and (max-width: $medium) // screen < $medium
   .account-card

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -79,7 +79,7 @@ export default defineComponent({
       } catch (e) {
         this.ram = this.cpu = this.net = ZERO;
         this.total = this.refunding = this.staked = this.rex = this.none;
-        console.log('account not found');
+        this.$q.notify(`account ${this.account} not found!`);
         return;
       }
       try {
@@ -87,7 +87,7 @@ export default defineComponent({
           await this.$api.getCreator(this.account)
         ).creator;
       } catch (e) {
-        console.log('no creating account found');
+        this.$q.notify(`creator account for ${this.account} not found!`);
       }
       const account = data.account;
       this.total = this.getAmount(account.core_liquid_balance);

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -38,7 +38,7 @@ import { defineComponent } from 'vue';
 import { mapGetters, mapMutations } from 'vuex';
 
 const HUNDRED = 100.0;
-const ZERO = '0.0';
+const ZERO = '0.00';
 const SYSTEM_ACCOUNT = 'eosio';
 
 export default defineComponent({

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -38,7 +38,7 @@ import { defineComponent } from 'vue';
 import { mapGetters, mapMutations } from 'vuex';
 
 const HUNDRED = 100.0;
-const NONE = '0 TLOS';
+const NONE = '0';
 const SYSTEM_ACCOUNT = 'eosio';
 
 export default defineComponent({
@@ -85,11 +85,14 @@ export default defineComponent({
           );
           this.setToken(token);
         }
-        this.staked = account.voter_info
-          ? (
-              account.voter_info.staked / Math.pow(10, this.token.precision)
-            ).toFixed(2)
-          : NONE;
+        if (account.voter_info) {
+          const stakedAmount = (
+            account.voter_info.staked / Math.pow(10, this.token.precision)
+          ).toFixed(2);
+          this.staked = `${stakedAmount} ${(this.token as Token).symbol}`;
+        } else {
+          this.staked = NONE;
+        }
         this.rex = account.rex_info ? account.rex_info.vote_stake : NONE;
         this.ram = (
           (account.ram_usage / account.total_resources.ram_bytes) *

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -39,7 +39,8 @@ import { mapGetters, mapMutations } from 'vuex';
 
 const HUNDRED = 100.0;
 const NONE = '0 TLOS';
-const SYSTEM_TOKEN = 'eosio.token';
+const SYSTEM_ACCOUNT = 'eosio';
+
 export default defineComponent({
   name: 'AccountCard',
   props: {
@@ -73,12 +74,14 @@ export default defineComponent({
       try {
         const data = await this.$api.getAccount(this.account);
         const account = data.account;
-        this.total = account.core_liquid_balance;
+        this.total = account.core_liquid_balance
+          ? account.core_liquid_balance
+          : NONE;
         this.refunding = account.refund_request ? account.refund_request : NONE;
         if (this.token.symbol === '') {
-          const tokenList = await this.$api.getTokens(SYSTEM_TOKEN);
+          const tokenList = await this.$api.getTokens(SYSTEM_ACCOUNT);
           const token = tokenList.find(
-            (token: Token) => token.contract === SYSTEM_TOKEN
+            (token: Token) => token.contract === `${SYSTEM_ACCOUNT}.token`
           );
           this.setToken(token);
         }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -47,6 +47,7 @@ export default defineComponent({
       console.log('connect btn clicked');
     },
     async menuClicked(routeName: string) {
+      return; //temp disable navigation
       await this.$router.push({ name: routeName.toLowerCase() });
       this.$router.go(0);
     },

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -33,7 +33,6 @@ div.header-background
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Notify } from 'quasar';
 import { isValidHex, isValidAccount } from 'src/utils/stringValidator';
 export default defineComponent({
   name: 'Header',
@@ -56,7 +55,7 @@ export default defineComponent({
       if (input != null) {
         const value = (input.currentTarget as HTMLInputElement).value;
         if (value === '') {
-          Notify.create('no search term input');
+          this.$q.notify('no search term input');
           return;
         }
         if (isValidHex(value) && value.length == 64) {
@@ -73,7 +72,7 @@ export default defineComponent({
             });
             this.$router.go(0);
           } else {
-            Notify.create('invalid transacation id or account name');
+            this.$q.notify('invalid transacation id or account name');
           }
         }
       }

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -47,7 +47,7 @@ export default defineComponent({
       console.log('connect btn clicked');
     },
     async menuClicked(routeName: string) {
-      await this.$router.push({ name: `${routeName}` });
+      await this.$router.push({ name: routeName.toLowerCase() });
       this.$router.go(0);
     },
     /* temp search check if possible tx or account, replace with results list rendering */

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -66,11 +66,18 @@ export default defineComponent({
           this.$router.go(0);
         } else {
           if (isValidAccount(value)) {
-            await this.$router.push({
-              name: 'account',
-              params: { account: value }
-            });
-            this.$router.go(0);
+            try {
+              await this.$api.getAccount(value);
+              await this.$router.push({
+                name: 'account',
+                params: {
+                  account: value
+                }
+              });
+              this.$router.go(0);
+            } catch (e) {
+              this.$q.notify(`account ${value} not found!`);
+            }
           } else {
             this.$q.notify('invalid transacation id or account name');
           }

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -10,6 +10,7 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/account/:account',
     name: 'account',
+    props: true,
     component: () => import('layouts/MainLayout.vue'),
     children: [{ path: '', component: () => import('pages/Account.vue') }]
   },

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -9,10 +9,16 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: '/account/:account',
-    name: 'account',
+    name: '',
     props: true,
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/Account.vue') }]
+    children: [
+      {
+        name: 'account',
+        path: '',
+        component: () => import('pages/Account.vue')
+      }
+    ]
   },
   {
     path: '/transaction/:transaction',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -9,12 +9,11 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: '/account/:account',
-    name: '',
+    name: 'account',
     props: true,
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {
-        name: 'account',
         path: '',
         component: () => import('pages/Account.vue')
       }

--- a/src/store/chain/getters.ts
+++ b/src/store/chain/getters.ts
@@ -1,10 +1,10 @@
-import { BaseToken } from 'src/types';
+import { Token } from 'src/types';
 import { GetterTree } from 'vuex';
 import { StateInterface } from '../index';
 import { ChainStateInterface } from './state';
 
 export const getters: GetterTree<ChainStateInterface, StateInterface> = {
-  getToken({ token }): BaseToken {
+  getToken({ token }): Token {
     return token;
   }
 };

--- a/src/store/chain/mutations.ts
+++ b/src/store/chain/mutations.ts
@@ -1,9 +1,9 @@
-import { BaseToken } from 'src/types';
+import { Token } from 'src/types';
 import { MutationTree } from 'vuex';
 import { ChainStateInterface } from './state';
 
 export const mutations: MutationTree<ChainStateInterface> = {
-  setToken(state: ChainStateInterface, token: BaseToken) {
+  setToken(state: ChainStateInterface, token: Token) {
     state.token = token;
   },
   setSymbol(state: ChainStateInterface, symbol: string) {

--- a/src/store/chain/state.ts
+++ b/src/store/chain/state.ts
@@ -1,15 +1,15 @@
+import { Token } from 'src/types';
 export interface ChainStateInterface {
-  token: {
-    symbol: string;
-    precision: number;
-  };
+  token: Token;
 }
 
 export function state(): ChainStateInterface {
   return {
     token: {
       symbol: '',
-      precision: 0
+      precision: 0,
+      amount: 0,
+      contract: ''
     }
   };
 }

--- a/src/types/Actions.ts
+++ b/src/types/Actions.ts
@@ -78,12 +78,9 @@ export interface AccountDetails {
   tokens: Token[];
   total_actions: number;
 }
-
-export interface BaseToken {
+export interface Token {
   symbol: string;
   precision: number;
-}
-export type Token = BaseToken & {
   amount: number;
   contract: string;
-};
+}

--- a/src/types/Actions.ts
+++ b/src/types/Actions.ts
@@ -49,7 +49,7 @@ interface Resource {
   max: number;
 }
 
-export interface AccountDetails {
+export type AccountDetails = {
   account: {
     account_name: string;
     core_liquid_balance: string;
@@ -77,7 +77,7 @@ export interface AccountDetails {
   query_time_ms: number;
   tokens: Token[];
   total_actions: number;
-}
+};
 export interface Token {
   symbol: string;
   precision: number;

--- a/src/types/GenericObj.ts
+++ b/src/types/GenericObj.ts
@@ -1,0 +1,4 @@
+export type GenericObj = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [key: string]: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,4 @@ export { GetTableRowsParams } from './Api';
 export { ActionData, Action, Account, Token, AccountDetails } from './Actions';
 export { TransactionTableRow } from './TransactionTableRow';
 export { PaginationSettings } from './PaginationSettings';
+export { GenericObj } from './GenericObj';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,13 +2,6 @@ export { Contract } from './Contract';
 export { PriceStats } from './PriceStats';
 export { PriceHistory, DateTuple } from './PriceHistory';
 export { GetTableRowsParams } from './Api';
-export {
-  ActionData,
-  Action,
-  Account,
-  Token,
-  AccountDetails,
-  BaseToken
-} from './Actions';
+export { ActionData, Action, Account, Token, AccountDetails } from './Actions';
 export { TransactionTableRow } from './TransactionTableRow';
 export { PaginationSettings } from './PaginationSettings';


### PR DESCRIPTION
## Description
- prevent navigation if non-existant account is searched on home/landing page (url will not update)
- if on valid account page and search for non-existant account,  remain on page, no loading data or change to url/route
- display temp notification toast to user if account not found
- error handling for no account, no creator account queries
- hide resource values & 'created by' for system account 
- general refactoring of methods in account card component

addresses #45 #54  #44 

Note regarding account creator error, this is a data error related to the specific endpoint provider missing data and unrelated to the application itself. Also, we can't suppress the endpoint failure message itself but I do have a handler to ensure it doesn't break the app.  