### PR TITLE
[ #161 ]  Proposal page shows all multi-signature proposals

### DIFF
--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -152,6 +152,7 @@ export const getProposals = async function ({
   proposal,
   requested,
   provided,
+  executed,
   limit,
   skip
 }: GetProposalsProps): Promise<GetProposals> {
@@ -161,6 +162,7 @@ export const getProposals = async function ({
       proposal,
       requested,
       provided,
+      executed,
       limit,
       skip
     }

--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -18,7 +18,10 @@ import {
   PermissionLinks,
   Userres,
   Block,
-  Get_actions
+  Get_actions,
+  GetProposalsProps,
+  GetProposals,
+  GetProducers
 } from 'src/types';
 
 const hyperion = axios.create({ baseURL: process.env.HYPERION_ENDPOINT });
@@ -141,5 +144,35 @@ export const getActions = async function (
       filter
     }
   });
+  return response.data;
+};
+
+export const getProposals = async function ({
+  proposer,
+  proposal,
+  requested,
+  provided,
+  limit,
+  skip
+}: GetProposalsProps): Promise<GetProposals> {
+  const response = await hyperion.get('v2/state/get_proposals', {
+    params: {
+      proposer,
+      proposal,
+      requested,
+      provided,
+      limit,
+      skip
+    }
+  });
+  return response.data;
+};
+
+export const getProducers = async function (): Promise<GetProducers> {
+  const response = await hyperion.post('v1/chain/get_producers', {
+    json: true,
+    limit: 10000
+  });
+
   return response.data;
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,7 +15,9 @@ import {
   getPermissionLinks,
   getTableByScope,
   getBlock,
-  getActions
+  getActions,
+  getProposals,
+  getProducers
 } from './hyperion'; //  e.g. './new-service' method name stays the same
 import { getTableRows, getTokenBalances } from './eosio_core';
 
@@ -32,5 +34,7 @@ export const api = {
   getPermissionLinks,
   getTableByScope,
   getBlock,
-  getActions
+  getActions,
+  getProposals,
+  getProducers
 };

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -4,6 +4,8 @@ import { isValidHex, isValidAccount } from 'src/utils/stringValidator';
 import { ref } from 'vue';
 import LoginHandler from 'components/LoginHandler.vue';
 import { OptionsObj } from 'src/types';
+import { useAuthenticator } from 'src/composables/useAuthenticator';
+
 export default defineComponent({
   name: 'Header',
   components: { LoginHandler },
@@ -16,9 +18,12 @@ export default defineComponent({
     const selected = ref<string>(null);
     const options = ref<OptionsObj[]>([]);
 
+    const { account } = useAuthenticator();
+
     return {
       selected,
-      options
+      options,
+      account
     };
   },
   computed: {
@@ -158,11 +163,11 @@ export default defineComponent({
       .q-px-xs-xs.q-px-sm-xs.q-px-md-md.q-px-lg-md
         .row.justify-center.full-width
           q-select.col-12.search-input(
-            borderless 
-            dense 
+            borderless
+            dense
             filled
             :model-value="selected"
-            label-color="white"  
+            label-color="white"
             color="primary"
             use-input
             hide-selected
@@ -170,7 +175,7 @@ export default defineComponent({
             input-debounce="0"
             :options="options"
             @update="executeSearch"
-            @keyup.enter="executeSearch" 
+            @keyup.enter="executeSearch"
             :input-style="{ color: 'white' }"
             @click="executeSearch"
             @input-value="getOptions")
@@ -179,28 +184,28 @@ export default defineComponent({
                     v-bind="scope.itemProps"
                     v-on="scope.itemEvents"
                     :disable="true"
-                )              
+                )
                   q-item-label(header) {{ scope.opt.label }}
                 q-item(
                   v-else
                   v-bind="scope.itemProps"
                   v-on="scope.itemEvents"
                   @click="suggestedSearch(scope.opt)"
-                )             
+                )
                   q-item-section
                     q-item-label(v-html="scope.opt.label")
 
               template(v-slot:prepend)
                 q-icon.search-icon(name="search" color="white" size="20px")
-                    
+
     LoginHandler
   .row.justify-center.col-12.q-pt-sm
     q-tabs(v-model="tab"  active-class="active-tab" indicator-color="white" align="justify" narrow-indicator color="white")
-      q-route-tab.deactive.active-tab(name="network" label="Network" to='/').temp-hide
-      q-route-tab.deactive(name="wallet" label="Wallet" to="{ name: 'account', params: {account: /* store account getter */} }").temp-hide
-      q-route-tab.deactive(name="vote" label="Vote" to='/vote').temp-hide
-      q-route-tab.deactive(name="proposal"  label="Proposal" to='/proposal').temp-hide
-      q-route-tab.deactive(name="explore" label="Explore" to='/explore').temp-hide
+      q-route-tab.deactive(name="network" label="Network" to='/')
+      q-route-tab.deactive(name="wallet" v-if="account" label="Wallet" :to="'/account/' + account")
+      //- q-route-tab.deactive(name="vote" label="Vote" to='/vote')
+      q-route-tab.deactive(name="proposal"  label="Proposal" to='/proposal')
+      //- q-route-tab.deactive(name="explore" label="Explore" to='/explore')
 </template>
 
 <style lang="sass" scoped>

--- a/src/components/ProposalTable.vue
+++ b/src/components/ProposalTable.vue
@@ -1,0 +1,237 @@
+<template lang="pug">
+q-table(
+  color="primary"
+  flat
+  :bordered="false"
+  :square="true"
+  :title="title"
+  table-header-class="text-grey-7"
+  :rows="rows"
+  :columns="columns"
+  row-key="proposalName"
+  :rows-per-page-options="[5,10,20,40,80,160]"
+  v-model:pagination="pagination"
+  @request="onRequest"
+)
+  template(v-slot:top)
+    div.q-table__control.full-width.justify-between
+      div.q-table__title(v-text="title")
+      div(v-if="type === 'needsYourSignature'")
+        q-toggle(label="Already signed" v-model="isSigned")
+      div(v-if="type === 'allProposals'")
+        q-btn-dropdown(outlined flat :label="blockProducer ? blockProducer : 'Filter by Block Producer'" v-model="filterDropdown")
+          div.q-pa-md
+            span.block.q-mb-sm.text-body3 Filter by pending signature from:
+            q-select(
+              outlined
+              dense
+              v-model="blockProducer"
+              label="Block Producer"
+              hide-bottom-space
+              hide-selected
+              fill-input
+              :options="optionsBlockProducers"
+              use-input
+              input-debounce="0"
+              clearable
+              @filter="onFilterBlockProducer"
+            )
+              template(v-slot:no-option)
+                q-item
+                  q-item-section No results
+
+  template(v-slot:no-data)
+    span.q-pa-md.full-width.text-center.text-body2.
+      No proposals
+
+  template(v-slot:body="props")
+    q-tr(:props="props")
+      q-td(key="proposalName" :props="props")
+        router-link(:to="'/proposal/' + props.row.proposalName" style="text-decoration:none").text-primary.cursor-pointer {{props.row.proposalName}}
+      q-td(key="approvalStatus" :props="props")
+        span {{ props.row.approvalStatus }}
+      q-td(key="proposer" :props="props")
+        router-link(:to="'/account/' + props.row.proposer" style="text-decoration:none").text-primary.cursor-pointer {{props.row.proposer}}
+      q-td(key="executed" :props="props")
+        q-badge(:color="props.row.executed ? 'green' : 'orange'" :label="props.row.executed ? 'EXECUTED' : 'NOT EXECUTED'")
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, watch, PropType } from 'vue';
+import { PaginationSettings } from 'src/types/PaginationSettings';
+import { GetProposals, ProposalTableRow } from 'src/types/Proposal';
+import { api } from 'src/api';
+
+const initialStatePagination = {
+  sortBy: 'desc',
+  descending: false,
+  page: 1,
+  rowsPerPage: 5,
+  rowsNumber: 5
+};
+
+export default defineComponent({
+  name: 'ProposalTable',
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+    account: {
+      type: String,
+      required: true
+    },
+    type: {
+      type: String as PropType<
+        'needsYourSignature' | 'proposalsCreated' | 'allProposals'
+      >,
+      required: true
+    },
+    blockProducers: {
+      type: Array as PropType<string[]>
+    }
+  },
+  setup(setupProps) {
+    const rows = ref<ProposalTableRow[]>([]);
+    const pagination = ref(initialStatePagination);
+    const isSigned = ref(false);
+    const blockProducer = ref('');
+    const filterDropdown = ref(false);
+
+    const columns = [
+      {
+        name: 'proposalName',
+        align: 'left',
+        label: 'PROPOSAL NAME',
+        field: 'proposalNameSliced'
+      },
+      {
+        name: 'approvalStatus',
+        align: 'left',
+        label: 'APPROVAL STATUS',
+        field: 'approvalStatus'
+      },
+      {
+        name: 'proposer',
+        align: 'left',
+        label: 'PROPOSER',
+        field: 'proposer'
+      },
+      {
+        name: 'executed',
+        align: 'left',
+        label: 'EXECUTED',
+        field: 'executed'
+      }
+    ];
+
+    async function onRequest(props: { pagination: PaginationSettings }) {
+      const { page, rowsPerPage, sortBy, descending } = props.pagination;
+      const { account } = setupProps;
+
+      const proposer = setupProps.type === 'proposalsCreated' ? account : '';
+
+      let requested = '';
+      if (setupProps.type === 'allProposals' && blockProducer.value) {
+        requested = blockProducer.value;
+      }
+      if (setupProps.type === 'needsYourSignature' && !isSigned.value) {
+        requested = account;
+      }
+
+      let provided = '';
+      if (setupProps.type === 'needsYourSignature' && isSigned.value) {
+        provided = account;
+      }
+
+      try {
+        const data: GetProposals = await api.getProposals({
+          proposer,
+          requested,
+          provided,
+          limit: rowsPerPage,
+          skip: (page - 1) * rowsPerPage
+        });
+
+        pagination.value = {
+          rowsNumber: data.total.value,
+          page: page,
+          rowsPerPage: rowsPerPage,
+          sortBy: sortBy,
+          descending: descending
+        };
+
+        rows.value = data.proposals.map((proposal) => {
+          const approvalStatus = `${proposal.provided_approvals.length}/${
+            proposal.provided_approvals.length +
+            proposal.requested_approvals.length
+          }`;
+
+          return {
+            primaryKey: proposal.primary_key,
+            proposalName: proposal.proposal_name,
+            approvalStatus,
+            proposer: proposal.proposer,
+            executed: proposal.executed
+          };
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
+    onMounted(async () => {
+      await onRequest({
+        pagination: pagination.value
+      });
+    });
+
+    watch(isSigned, async () => {
+      pagination.value = initialStatePagination;
+      await onRequest({
+        pagination: pagination.value
+      });
+    });
+
+    watch(blockProducer, async () => {
+      pagination.value = initialStatePagination;
+      filterDropdown.value = false;
+      await onRequest({
+        pagination: pagination.value
+      });
+    });
+
+    const optionsBlockProducers = ref<string[]>(setupProps.blockProducers);
+    function onFilterBlockProducer(
+      inputValue: string,
+      update: (callback: () => void) => void
+    ) {
+      if (inputValue === '') {
+        update(() => {
+          optionsBlockProducers.value = setupProps.blockProducers;
+        });
+        return;
+      }
+
+      update(() => {
+        const formattedValue = inputValue.toLowerCase();
+        optionsBlockProducers.value = setupProps.blockProducers.filter(
+          (item) => item.toLowerCase().indexOf(formattedValue) > -1
+        );
+      });
+    }
+
+    return {
+      columns,
+      rows,
+      pagination,
+      isSigned,
+      blockProducer,
+      optionsBlockProducers,
+      filterDropdown,
+      onRequest,
+      onFilterBlockProducer
+    };
+  }
+});
+</script>

--- a/src/composables/useAuthenticator.ts
+++ b/src/composables/useAuthenticator.ts
@@ -1,0 +1,35 @@
+import { getCurrentInstance, computed, ComputedRef } from 'vue';
+import { UAL, Authenticator, User } from 'universal-authenticator-library';
+import { useStore } from 'src/store';
+
+interface UseAuthenticatorReturn {
+  account: ComputedRef<string>;
+  isAuthenticated: ComputedRef<boolean>;
+  getUser: () => Promise<User>;
+}
+
+export function useAuthenticator(): UseAuthenticatorReturn {
+  const app = getCurrentInstance();
+
+  const store = useStore();
+  const account = computed((): string => store.state.account.accountName);
+  const isAuthenticated = computed(
+    (): boolean => !!store.state.account.accountName
+  );
+
+  async function getUser() {
+    const $ual = app.appContext.config.globalProperties.$ual as UAL;
+
+    const authenticators: Authenticator[] =
+      $ual.getAuthenticators().availableAuthenticators;
+    const users: User[] = await authenticators[0].login();
+
+    return users[0];
+  }
+
+  return {
+    account,
+    isAuthenticated,
+    getUser
+  };
+}

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -12,7 +12,7 @@
 
 .cursor-pointer
   cursor: pointer
-    
+
 .separator
     min-width: 100%
     min-height: 2px
@@ -38,7 +38,7 @@
     font-size: 22.75px
     line-height: 27px
 
-.q-select__dropdown-icon
+.search-input .q-select__dropdown-icon
   color: white !important
 
 .maxSize
@@ -53,4 +53,3 @@
     border-radius: 4px
     padding-left: 20px
     background: rgba(138, 101, 212, 0.1)
-

--- a/src/pages/Proposal.vue
+++ b/src/pages/Proposal.vue
@@ -1,4 +1,83 @@
 <template lang="pug">
-div
-    h1 Proposal
+q-page(padding)
+  div.row.justify-between.items-center.q-pt-lg.q-pb-sm
+    h1.text-h5.q-ma-none Multisig Transactions
+
+  q-tabs(v-model="tab" align="left" active-color="primary" content-class="text-grey-7"  no-caps)
+    q-tab(v-if="isLogged" name="myProposal" label="My proposals")
+    q-tab(name="allProposal" label="All proposals")
+
+  q-separator
+
+  q-tab-panels(v-model="tab")
+    q-tab-panel(v-if="isLogged" name="myProposal").q-pa-none
+      div.q-py-lg
+        ProposalTable(
+          title="Needs your signature"
+          type="needsYourSignature"
+          :account="account"
+        )
+        ProposalTable(
+          title="Proposals created"
+          type="proposalsCreated"
+          :account="account"
+        )
+
+    q-tab-panel(name="allProposal").q-pa-none
+      div.q-py-lg
+        ProposalTable(
+          title="Proposals"
+          type="allProposals"
+          :account="account"
+          :blockProducers="blockProducers"
+        )
 </template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted } from 'vue';
+import { useStore } from '../store';
+import ProposalTable from 'src/components/ProposalTable.vue';
+import { api } from 'src/api';
+
+export default defineComponent({
+  name: 'Proposal',
+  components: {
+    ProposalTable
+  },
+  setup() {
+    const store = useStore();
+    const isLogged = computed((): boolean => !!store.state.account.accountName);
+    const account = computed((): string => store.state.account.accountName);
+    const blockProducers = ref<string[]>([]);
+
+    const tab = ref<'myProposal' | 'allProposal'>('myProposal');
+
+    onMounted(() => {
+      if (!isLogged.value) {
+        tab.value = 'allProposal';
+      }
+    });
+
+    onMounted(async () => {
+      const producers = await api.getProducers();
+      const producersAccount = [] as string[];
+
+      for (let index = 0; index < producers.rows.length; index++) {
+        const item = producers.rows[index];
+        if (item.is_active === 1) {
+          producersAccount.push(item.owner);
+        }
+      }
+
+      blockProducers.value = producersAccount;
+    });
+
+    return {
+      tab,
+      account,
+      isLogged,
+      blockProducers
+    };
+  }
+});
+</script>

--- a/src/pages/Proposal.vue
+++ b/src/pages/Proposal.vue
@@ -4,13 +4,13 @@ q-page(padding)
     h1.text-h5.q-ma-none Multisig Transactions
 
   q-tabs(v-model="tab" align="left" active-color="primary" content-class="text-grey-7"  no-caps)
-    q-tab(v-if="isLogged" name="myProposal" label="My proposals")
+    q-tab(v-if="isAuthenticated" name="myProposal" label="My proposals")
     q-tab(name="allProposal" label="All proposals")
 
   q-separator
 
   q-tab-panels(v-model="tab")
-    q-tab-panel(v-if="isLogged" name="myProposal").q-pa-none
+    q-tab-panel(v-if="isAuthenticated" name="myProposal").q-pa-none
       div.q-py-lg
         ProposalTable(
           title="Needs your signature"
@@ -34,10 +34,10 @@ q-page(padding)
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, onMounted } from 'vue';
-import { useStore } from '../store';
+import { defineComponent, ref, onMounted } from 'vue';
 import ProposalTable from 'src/components/ProposalTable.vue';
 import { api } from 'src/api';
+import { useAuthenticator } from 'src/composables/useAuthenticator';
 
 export default defineComponent({
   name: 'Proposal',
@@ -45,15 +45,13 @@ export default defineComponent({
     ProposalTable
   },
   setup() {
-    const store = useStore();
-    const isLogged = computed((): boolean => !!store.state.account.accountName);
-    const account = computed((): string => store.state.account.accountName);
     const blockProducers = ref<string[]>([]);
+    const { account, isAuthenticated } = useAuthenticator();
 
     const tab = ref<'myProposal' | 'allProposal'>('myProposal');
 
     onMounted(() => {
-      if (!isLogged.value) {
+      if (!isAuthenticated.value) {
         tab.value = 'allProposal';
       }
     });
@@ -75,7 +73,7 @@ export default defineComponent({
     return {
       tab,
       account,
-      isLogged,
+      isAuthenticated,
       blockProducers
     };
   }

--- a/src/types/Actions.ts
+++ b/src/types/Actions.ts
@@ -176,7 +176,26 @@ export interface Block {
   schedule_version: number;
   new_producers: null | string;
   producer_signature: string;
-  transactions: string[];
+  transactions: {
+    trx: {
+      id: string;
+      transaction: {
+        actions: {
+          account: string;
+          authorization: {
+            actor: string;
+            permission: string;
+          }[];
+          data: {
+            executer: string;
+            proposal_name: string;
+            proposer: string;
+          };
+          name: string;
+        }[];
+      }[];
+    };
+  }[];
   id: string;
   block_num: number;
   ref_block_prefix: number;

--- a/src/types/PaginationSettings.ts
+++ b/src/types/PaginationSettings.ts
@@ -3,4 +3,5 @@ export interface PaginationSettings {
   descending: boolean;
   page: number;
   rowsPerPage: number;
+  rowsNumber?: number;
 }

--- a/src/types/Producers.ts
+++ b/src/types/Producers.ts
@@ -1,0 +1,6 @@
+export interface GetProducers {
+  rows: {
+    owner: string;
+    is_active: number;
+  }[];
+}

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -1,0 +1,74 @@
+export interface GetProposalsProps {
+  proposer?: string;
+  proposal?: string;
+  requested?: string;
+  provided?: string;
+  limit?: number;
+  skip?: number;
+}
+
+export interface GetProposals {
+  proposals: {
+    block_num: number;
+    executed: false;
+    primary_key: string;
+    proposal_name: string;
+    proposer: string;
+    provided_approvals: {
+      actor: string;
+      permission: string;
+      time: string;
+    }[];
+    requested_approvals: {
+      actor: string;
+      permission: string;
+      time: string;
+    }[];
+  }[];
+  total: {
+    value: number;
+  };
+}
+
+export interface ProposalTableRow {
+  primaryKey: string;
+  proposalName: string;
+  approvalStatus: string;
+  proposer: string;
+  isSigned?: boolean;
+}
+
+export interface ProposalForm {
+  proposer: string;
+  proposal_name: string;
+
+  requested: {
+    actor: string;
+    permission: string;
+  }[];
+
+  trx: {
+    expiration: string;
+    ref_block_num: number;
+    ref_block_prefix: number;
+    max_net_usage_words: number;
+    max_cpu_usage_ms: number;
+    delay_sec: number;
+    context_free_actions: string[];
+    transaction_extensions: string[];
+
+    actions: {
+      account: string;
+      name: string;
+      from: string;
+      to: string;
+      quantity: string;
+      memo: string;
+      authorization: {
+        actor: string;
+        permission: string;
+      }[];
+      data: string;
+    }[];
+  };
+}

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -3,6 +3,7 @@ export interface GetProposalsProps {
   proposal?: string;
   requested?: string;
   provided?: string;
+  executed?: boolean;
   limit?: number;
   skip?: number;
 }
@@ -60,15 +61,16 @@ export interface ProposalForm {
     actions: {
       account: string;
       name: string;
-      from: string;
-      to: string;
-      quantity: string;
-      memo: string;
       authorization: {
         actor: string;
         permission: string;
       }[];
-      data: string;
+      data: {
+        from: string;
+        to: string;
+        quantity: string;
+        memo: string;
+      };
     }[];
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,3 +26,5 @@ export { Transaction } from './Transaction';
 export { OptionsObj } from './OptionsObj';
 export { TreeNode } from './TreeNode';
 export { RexbalRows, Rexbal } from './TableRows';
+export { GetProposalsProps, GetProposals } from './Proposal';
+export { GetProducers } from './Producers';


### PR DESCRIPTION
# Pull Request Template

## Description
This PR creates a page in the `proposal` route. This page will show any user all the multi-signature proposals in the network. These proposals can be filtered by the Block Producer which signature is needed. 

For logged in users, the page also contains the `my proposals` tab which contains two lists: the first one is the proposals that need to be signed or have already been signed by the user, the second is the proposals that the user has created.

Fixes # 161

### Notes
The scoping of white color for `q-select__dropdown-icon` [here](https://github.com/telosnetwork/open-block-explorer/compare/develop...161-msig-proposals#diff-87f65ea85740352e3eb5d7734f51f3fabd8f77b96a013e4a550b1399972606bdR41) was due to the impact it had in the overall select element. We moved so only the search component has its icon white, where the BP selector maintains 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Manual test  as logged in user on chrome, firefox and safari
- [x] Manual test not logged in user on chrome, firefox and safari
- [x] Manual tests filtering all proposals by block producer that needs to sign
- [x] Manual tests as logged in user in my proposals and filtering them by already signed

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] ~New and~ existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

