### PR TITLE
[Closes #184] Enable users to use search bar for m-sig proposals

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,152 +1,25 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
-import { isValidHex, isValidAccount } from 'src/utils/stringValidator';
-import { ref } from 'vue';
+import { defineComponent, computed } from 'vue';
+import { useQuasar } from 'quasar';
 import LoginHandler from 'components/LoginHandler.vue';
-import { OptionsObj } from 'src/types';
+import HeaderSearch from 'components/HeaderSearch.vue';
 import { useAuthenticator } from 'src/composables/useAuthenticator';
 
 export default defineComponent({
   name: 'Header',
-  components: { LoginHandler },
-  data() {
-    return {
-      tab: 'Network'
-    };
+  components: {
+    LoginHandler,
+    HeaderSearch
   },
   setup() {
-    const selected = ref<string>(null);
-    const options = ref<OptionsObj[]>([]);
-
+    const $q = useQuasar();
     const { account } = useAuthenticator();
+    const isSmall = computed((): boolean => $q.screen.gt.sm);
 
     return {
-      selected,
-      options,
-      account
+      account,
+      isSmall
     };
-  },
-  computed: {
-    isSmall(): boolean {
-      return this.$q.screen.gt.sm;
-    }
-  },
-  methods: {
-    /* temp search check if possible tx or account, replace with results list rendering */
-    async executeSearch(input: KeyboardEvent): Promise<void> {
-      if (input != null) {
-        const value = (input.currentTarget as HTMLInputElement).value;
-        if (value === '') {
-          this.$q.notify('no search term input');
-          return;
-        }
-        if (isValidHex(value) && value.length == 64) {
-          const check = await this.$api.getTransaction(value);
-          if (check) {
-            await this.$router.push({
-              name: 'transaction',
-              params: { transaction: value }
-            });
-            this.$router.go(0);
-          } else {
-            this.$q.notify(`transaction ${value} not found!`);
-          }
-        } else {
-          if (isValidAccount(value)) {
-            let account: string;
-            try {
-              account = value.toLowerCase();
-              await this.$api.getAccount(account);
-              await this.$router.push({
-                name: 'account',
-                params: {
-                  account
-                }
-              });
-              this.$router.go(0);
-            } catch (e) {
-              this.$q.notify(`account ${account} not found!`);
-            }
-          } else {
-            this.$q.notify('invalid transacation id or account name');
-          }
-        }
-      }
-    },
-    async suggestedSearch(): Promise<void> {
-      const value = this.selected;
-      if (value === '') {
-        this.$q.notify('no search term input');
-        return;
-      }
-      if (isValidHex(value) && value.length == 64) {
-        const check = await this.$api.getTransaction(value);
-        if (check) {
-          await this.$router.push({
-            name: 'transaction',
-            params: { transaction: value }
-          });
-          this.$router.go(0);
-        } else {
-          this.$q.notify(`transaction ${value} not found!`);
-        }
-      } else {
-        if (isValidAccount(value)) {
-          let account: string;
-          try {
-            account = value.toLowerCase();
-            await this.$api.getAccount(account);
-            await this.$router.push({
-              name: 'account',
-              params: {
-                account
-              }
-            });
-            this.$router.go(0);
-          } catch (e) {
-            this.$q.notify(`account ${account} not found!`);
-          }
-        } else {
-          this.$q.notify('invalid transacation id or account name');
-        }
-      }
-    },
-    async getOptions(val: string): Promise<void> {
-      this.selected = val;
-      if (this.selected != null) {
-        var account: string;
-        try {
-          account = this.selected.toLowerCase();
-          const value = await this.$api.getTableByScope(account);
-          this.options = [];
-          if (value.length > 0) {
-            this.options.push({
-              label: 'Accounts',
-              groupLabel: true,
-              group: 'account',
-              disabled: true
-            });
-          }
-          value.forEach((user) => {
-            this.options.push({
-              label: user.payer,
-              groupLabel: false,
-              group: 'account',
-              disabled: false
-            });
-          });
-          if (value.length === 1) {
-            this.selected = value[0].payer;
-            await this.suggestedSearch();
-          }
-        } catch (e) {
-          return;
-        }
-      }
-    }
-  },
-  async mounted() {
-    await this.getOptions('');
   }
 });
 </script>
@@ -162,45 +35,12 @@ export default defineComponent({
     .col-xs-5.col-sm-6.col-md-4.col-lg-6
       .q-px-xs-xs.q-px-sm-xs.q-px-md-md.q-px-lg-md
         .row.justify-center.full-width
-          q-select.col-12.search-input(
-            borderless
-            dense
-            filled
-            :model-value="selected"
-            label-color="white"
-            color="primary"
-            use-input
-            hide-selected
-            fill-input
-            input-debounce="0"
-            :options="options"
-            @update="executeSearch"
-            @keyup.enter="executeSearch"
-            :input-style="{ color: 'white' }"
-            @click="executeSearch"
-            @input-value="getOptions")
-              template( v-slot:option="scope")
-                q-item(v-if="scope.opt.groupLabel"
-                    v-bind="scope.itemProps"
-                    v-on="scope.itemEvents"
-                    :disable="true"
-                )
-                  q-item-label(header) {{ scope.opt.label }}
-                q-item(
-                  v-else
-                  v-bind="scope.itemProps"
-                  v-on="scope.itemEvents"
-                  @click="suggestedSearch(scope.opt)"
-                )
-                  q-item-section
-                    q-item-label(v-html="scope.opt.label")
-
-              template(v-slot:prepend)
-                q-icon.search-icon(name="search" color="white" size="20px")
+          .col-12
+            HeaderSearch
 
     LoginHandler
   .row.justify-center.col-12.q-pt-sm
-    q-tabs(v-model="tab"  active-class="active-tab" indicator-color="white" align="justify" narrow-indicator color="white")
+    q-tabs(active-class="active-tab" indicator-color="white" align="justify" narrow-indicator color="white")
       q-route-tab.deactive(name="network" label="Network" to='/')
       q-route-tab.deactive(name="wallet" v-if="account" label="Wallet" :to="'/account/' + account")
       //- q-route-tab.deactive(name="vote" label="Vote" to='/vote')
@@ -209,47 +49,29 @@ export default defineComponent({
 </template>
 
 <style lang="sass" scoped>
-$medium:750px
-
 .q-tab
   text-transform: unset
   font-size: 18px
 
 .logo
-    width: 104px
-    height:40px
+  width: 104px
+  height:40px
 .logo-tlos
-    width: 40px
-    height: 40px
-
-.search-container
-  margin-left: 1rem
+  width: 40px
+  height: 40px
 
 .header-items
-    list-style-type: none
+  list-style-type: none
 
 .active-tab
-    text-decoration: none
-    color: #ffffff
-    opacity: 1 !important
+  text-decoration: none
+  color: #ffffff
+  opacity: 1 !important
 
 .deactive
-    opacity: 0.3
-    font-size: 18px
+  opacity: 0.3
+  font-size: 18px
 
 .header-background
-    background: $primary-dark
-
-.search-input
-    background: rgba(255, 255, 255, 0.05)
-    border-radius: 4px
-
-.search-icon
-    transform: rotate(90deg)
-
-@media screen and (max-width: $medium) // screen < $medium
-
-  .search-container
-    width: 60%
-    color: white
+  background: $primary-dark
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -204,7 +204,7 @@ export default defineComponent({
       q-route-tab.deactive(name="network" label="Network" to='/')
       q-route-tab.deactive(name="wallet" v-if="account" label="Wallet" :to="'/account/' + account")
       //- q-route-tab.deactive(name="vote" label="Vote" to='/vote')
-      //- q-route-tab.deactive(name="proposal"  label="Proposal" to='/proposal')
+      q-route-tab.deactive(name="proposal"  label="Proposal" to='/proposal')
       //- q-route-tab.deactive(name="explore" label="Explore" to='/explore')
 </template>
 

--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -1,0 +1,190 @@
+<template lang="pug">
+q-select(
+  borderless
+  dense
+  filled
+  use-input
+  hide-selected
+  fill-input
+  hide-bottom-space
+  input-style="color:white"
+  color="white"
+  :loading="isLoading"
+  :model-value="inputValue"
+  @input-value="(value: string) => inputValue = value"
+  @keyup.enter="handleGoTo"
+  :options="options"
+  :option-disable="(item) => item.isHeader"
+).search-input
+  template(#prepend)
+    q-icon(name="search" color="white" size="20px").rotate-90
+
+  template(#no-option)
+    q-item
+      q-item-section.text-center
+        q-item-label(v-if="isLoading") Searching...
+        q-item-label(v-else) {{ inputValue ? 'Nothing found' : 'Search by accounts, proposals and transactions' }}
+
+  template(#option="scope")
+    q-item-label(v-if="scope.opt.isHeader" header) {{ scope.opt.label }}
+    q-item(v-else v-bind="scope.itemProps" exact @click="handleGoTo" clickable)
+      q-item-section
+        q-item-label {{ scope.opt.label }}
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, toRaw, watch } from 'vue';
+import { useRouter } from 'vue-router';
+import { OptionsObj } from 'src/types';
+import { api } from 'src/api';
+
+export default defineComponent({
+  name: 'HeaderSearch',
+  setup() {
+    const router = useRouter();
+
+    const inputValue = ref('');
+    const options = ref<OptionsObj[]>([]);
+    const isLoading = ref(false);
+
+    const waitToSearch = ref<ReturnType<typeof setTimeout> | null>(null);
+
+    watch(inputValue, (currentValue) => {
+      isLoading.value = true;
+
+      if (waitToSearch.value) {
+        clearTimeout(waitToSearch.value);
+      }
+
+      if (currentValue === '') {
+        options.value = [];
+        isLoading.value = false;
+        return;
+      }
+
+      waitToSearch.value = setTimeout(() => {
+        waitToSearch.value = null;
+      }, 1000);
+    });
+
+    watch(waitToSearch, async (currentValue) => {
+      if (!currentValue) {
+        const queryValue = inputValue.value.toLowerCase();
+        options.value = [];
+
+        await Promise.all([
+          searchAccounts(queryValue),
+          searchProposals(queryValue),
+          searchTransactions(queryValue)
+        ]);
+
+        isLoading.value = false;
+      }
+    });
+
+    async function searchAccounts(value: string): Promise<void> {
+      try {
+        const accounts = await api.getTableByScope(value);
+
+        if (accounts.length > 0) {
+          options.value.push({
+            label: 'Accounts',
+            to: '',
+            isHeader: true
+          });
+
+          accounts.forEach((user) => {
+            options.value.push({
+              label: user.payer,
+              to: `/account/${user.payer}`,
+              isHeader: false
+            });
+          });
+        }
+      } catch (error) {
+        return;
+      }
+    }
+
+    async function searchProposals(value: string): Promise<void> {
+      try {
+        const { proposals } = await api.getProposals({ proposal: value });
+
+        if (proposals.length > 0) {
+          options.value.push({
+            label: 'Proposals',
+            to: '',
+            isHeader: true
+          });
+
+          proposals.forEach((item) => {
+            options.value.push({
+              label: item.proposal_name,
+              to: `/proposal/${item.proposal_name}`,
+              isHeader: false
+            });
+          });
+        }
+      } catch (error) {
+        return;
+      }
+    }
+
+    async function searchTransactions(value: string): Promise<void> {
+      if (value.length !== 64) {
+        return;
+      }
+
+      try {
+        const transactions = await api.getTransaction(value);
+
+        if (transactions?.actions) {
+          options.value.push({
+            label: 'Transactions',
+            to: '',
+            isHeader: true
+          });
+
+          options.value.push({
+            label: value,
+            to: `/transaction/${value}`,
+            isHeader: false
+          });
+        }
+      } catch (error) {
+        return;
+      }
+    }
+
+    async function handleGoTo() {
+      const optionsRaw = toRaw(options.value);
+
+      if (!inputValue.value || optionsRaw.length === 0) {
+        return;
+      }
+
+      const option = optionsRaw.find((item) => item.label === inputValue.value);
+      const to = option ? option.to : optionsRaw[1].to;
+
+      await router.push(to);
+      router.go(0);
+    }
+
+    return {
+      inputValue,
+      options,
+      isLoading,
+      handleGoTo
+    };
+  }
+});
+</script>
+
+<style lang="sass">
+.search-input
+  background: rgba(255, 255, 255, 0.05)
+  border-radius: 4px
+
+.search-input .q-select__dropdown-icon
+  color: white
+</style>

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -41,9 +41,6 @@
     font-size: 22.75px
     line-height: 27px
 
-.search-input .q-select__dropdown-icon
-  color: white !important
-
 .maxSize
   max-width: 800px !important
 

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -1,0 +1,308 @@
+<template lang="pug">
+div.full-width.row.justify-center.items-center.gradient-box
+  div.col.text-center
+    h1.text-h4.text-white.q-ma-none Proposal {{proposalName}}
+    p.text-caption.text-white.text-uppercase.q-mt-xs(:style="{opacity:'0.5'}").
+      PROPOSER <router-link :to="'/account/' + proposer" class="text-white cursor-pointer">{{proposer}}</router-link> • APPROVAL STATUS {{approvalStatus}}
+    div(v-if="account").row.justify-center.items-center
+      q-btn(outline padding="sm md" color="white" text-color="white" label="Approve" @click="onApprove").q-mr-sm
+      q-btn(outline padding="sm md" color="white" text-color="white" label="Execute" @click="onExecute").q-mr-sm
+      q-btn(outline padding="sm md" color="white" text-color="white" label="Cancel" @click="onCancel")
+
+q-page(padding)
+  h2.text-h6.text-weight-regular Transaction
+  q-card
+    q-card-section.overflow-auto
+      router-link(:to="'/transaction/' + transactionId" style="text-decoration:none").text-primary.cursor-pointer {{transactionId}}
+  q-card.q-mt-md
+    json-viewer(
+      :value="transactionData"
+      :expand-depth="5"
+      preview-mode
+      boxed
+      copyable
+      sort
+    )
+
+  h2.text-h6.text-weight-regular.q-mt-xl Requested Approvals
+    span.text-body1.q-ml-sm.text-grey {{approvalStatus}}
+  q-card.q-mb-xl
+    q-table(
+        color="primary"
+        flat
+        :bordered="false"
+        :square="true"
+        table-header-class="text-grey-7"
+        :rows="requestedApprovalsRows"
+        :columns="requestedApprovalsColumns"
+        row-key="index"
+        :rows-per-page-options="[5,10,20,40,80,160]"
+      )
+        template(v-slot:body-cell-actor="props")
+          q-td(:props="props")
+            router-link(:to="'/account/' + props.value" style="text-decoration:none").text-primary.cursor-pointer {{props.value}}
+        template(v-slot:body-cell-status="props")
+          q-td(:props="props")
+            q-badge(:color="props.value ? 'green' : 'orange'" :label="props.value ? 'APPROVED' : 'PENDING'")
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useQuasar } from 'quasar';
+import JsonViewer from 'vue-json-viewer';
+import { api } from 'src/api';
+import { useAuthenticator } from 'src/composables/useAuthenticator';
+import { RequestedApprovals, Error } from 'src/types';
+
+export default defineComponent({
+  name: 'ProposalItem',
+  components: {
+    JsonViewer: JsonViewer as unknown
+  },
+  setup() {
+    const route = useRoute();
+    const router = useRouter();
+    const $q = useQuasar();
+
+    const { proposalName } = route.params;
+    const { account, getUser } = useAuthenticator();
+
+    const proposer = ref('');
+    const approvalStatus = ref('');
+    const requestedApprovalsRows = ref<RequestedApprovals[]>([]);
+
+    const transactionId = ref('');
+    const transactionData = ref<unknown>({});
+
+    const requestedApprovalsColumns = [
+      {
+        name: 'index',
+        align: 'left',
+        label: '#',
+        field: 'index'
+      },
+      {
+        name: 'actor',
+        align: 'left',
+        label: 'ACTOR',
+        field: 'actor'
+      },
+      {
+        name: 'permission',
+        align: 'left',
+        label: 'PERMISSION',
+        field: 'permission'
+      },
+      {
+        name: 'status',
+        align: 'left',
+        label: 'STATUS',
+        field: 'status'
+      }
+    ];
+
+    onMounted(async () => {
+      try {
+        const {
+          proposals: [proposal]
+        } = await api.getProposals({
+          proposal: proposalName as string,
+          limit: 1
+        });
+
+        if (typeof proposal === 'undefined') {
+          await router.push('/proposal');
+        }
+
+        proposer.value = proposal.proposer;
+        approvalStatus.value = `${proposal.provided_approvals.length}/${
+          proposal.provided_approvals.length +
+          proposal.requested_approvals.length
+        }`;
+
+        let requestedApprovals: RequestedApprovals[] = [];
+
+        proposal.requested_approvals.forEach((item) => {
+          requestedApprovals.push({
+            actor: item.actor,
+            permission: item.permission,
+            status: false,
+            index: 0
+          });
+        });
+
+        proposal.provided_approvals.forEach((item) => {
+          requestedApprovals.push({
+            actor: item.actor,
+            permission: item.permission,
+            status: true,
+            index: 0
+          });
+        });
+
+        requestedApprovalsRows.value = requestedApprovals.map(
+          (item, index) => ({
+            ...item,
+            index: index + 1
+          })
+        );
+
+        const block = await api.getBlock(String(proposal.block_num));
+        transactionId.value = block.transactions[0].trx.id;
+
+        const transaction = await api.getTransaction(transactionId.value);
+        transactionData.value = transaction.actions[0].act.data;
+      } catch (e) {
+        const error = JSON.parse(JSON.stringify(e)) as Error;
+        $q.notify({
+          color: 'negative',
+          message: error?.cause?.json?.error?.what || 'Proposal not found',
+          actions: [
+            {
+              label: 'Dismiss',
+              color: 'white'
+            }
+          ]
+        });
+        await router.push('/proposal');
+      }
+    });
+
+    async function signTransaction({
+      name,
+      data
+    }: {
+      name: 'approve' | 'cancel' | 'exec' | 'invalidate';
+      data: unknown;
+    }) {
+      const user = await getUser();
+
+      const response = await user.signTransaction(
+        {
+          actions: [
+            {
+              account: 'eosio.msig',
+              name,
+              authorization: [
+                {
+                  actor: account.value,
+                  permission: 'active'
+                }
+              ],
+              data
+            }
+          ]
+        },
+        {
+          blocksBehind: 3,
+          expireSeconds: 30
+        }
+      );
+
+      return response;
+    }
+
+    async function onApprove() {
+      try {
+        await signTransaction({
+          name: 'approve',
+          data: {
+            proposer: proposer.value,
+            proposal_name: proposalName,
+            level: {
+              actor: account.value,
+              permission: 'active'
+            }
+          }
+        });
+
+        document.location.reload();
+      } catch (e) {
+        const error = JSON.parse(JSON.stringify(e)) as Error;
+        $q.notify({
+          color: 'negative',
+          message: error?.cause?.json?.error?.what || 'Unable approve proposal',
+          actions: [
+            {
+              label: 'Dismiss',
+              color: 'white'
+            }
+          ]
+        });
+      }
+    }
+
+    async function onExecute() {
+      try {
+        await signTransaction({
+          name: 'exec',
+          data: {
+            proposer: proposer.value,
+            proposal_name: proposalName,
+            executer: account.value
+          }
+        });
+
+        document.location.reload();
+      } catch (e) {
+        const error = JSON.parse(JSON.stringify(e)) as Error;
+        $q.notify({
+          color: 'negative',
+          message: error?.cause?.json?.error?.what || 'Unable execute proposal',
+          actions: [
+            {
+              label: 'Dismiss',
+              color: 'white'
+            }
+          ]
+        });
+      }
+    }
+
+    async function onCancel() {
+      try {
+        await signTransaction({
+          name: 'cancel',
+          data: {
+            proposer: proposer.value,
+            proposal_name: proposalName,
+            canceler: account.value
+          }
+        });
+
+        document.location.reload();
+      } catch (e) {
+        const error = JSON.parse(JSON.stringify(e)) as Error;
+        $q.notify({
+          color: 'negative',
+          message: error?.cause?.json?.error?.what || 'Unable cancel proposal',
+          actions: [
+            {
+              label: 'Dismiss',
+              color: 'white'
+            }
+          ]
+        });
+      }
+    }
+
+    return {
+      account,
+
+      proposalName,
+      proposer,
+      approvalStatus,
+      transactionId,
+      transactionData,
+
+      requestedApprovalsRows,
+      requestedApprovalsColumns,
+
+      onApprove,
+      onExecute,
+      onCancel
+    };
+  }
+});
+</script>

--- a/src/pages/ProposalNew.vue
+++ b/src/pages/ProposalNew.vue
@@ -176,8 +176,8 @@ q-page(padding)
                   span.text-h6.text-weight-regular(v-else) Action {{index + 1}}
                 div.col-12.col-sm
                   span.text-body2(v-if="item.dataAction.from && item.dataAction.to && item.dataAction.quantity") <b>{{item.dataAction.from}} → {{item.dataAction.to}}</b> {{item.dataAction.quantity}}
-            div(v-if="formData.trx.actions.length !== 1")
-              q-btn(outline padding="sm md" color="white" text-color="primary" label="Remove" @click.stop="formData.trx.actions.splice(index, 1)")
+            div
+              q-btn(outline padding="sm md" color="white" text-color="primary" label="Remove" :disabled="formData.trx.actions.length === 1" @click.stop="formData.trx.actions.splice(index, 1)")
         div.q-pa-md
           div.row.q-col-gutter-md.q-mb-md
             div.col-6.col-sm-4
@@ -265,7 +265,7 @@ q-page(padding)
                 label="Permission (e.g. active)"
                 :rules="[value => !!value || 'Field is required']")
             div.col-sm-4
-              q-btn(outline padding="sm md" color="white" text-color="primary" label="Remove" @click="item.authorization.splice(authorizationIndex, 1)")
+              q-btn(outline padding="sm md" color="white" text-color="primary" label="Remove" :disable="item.authorization.length === 1" @click="item.authorization.splice(authorizationIndex, 1)")
 
           q-btn(outline padding="sm md" color="white" text-color="primary" label="Add" @click.stop="item.authorization.push({})")
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -57,6 +57,12 @@ const routes: RouteRecordRaw[] = [
     ]
   },
   {
+    path: '/proposal/:proposalName',
+    name: 'ProposalItem',
+    component: () => import('layouts/MainLayout.vue'),
+    children: [{ path: '', component: () => import('pages/ProposalItem.vue') }]
+  },
+  {
     path: '/explore',
     name: 'explore',
     component: () => import('layouts/MainLayout.vue'),

--- a/src/types/OptionsObj.ts
+++ b/src/types/OptionsObj.ts
@@ -1,6 +1,5 @@
 export type OptionsObj = {
   label: string;
-  group: string;
-  groupLabel: boolean;
-  disabled: boolean;
+  to: string;
+  isHeader: boolean;
 };


### PR DESCRIPTION
# Pull Request Template
DO NOT MERGE BEFORE PR #185

## Description

Users can now find m-sig proposals using the search bar by the proposal name.

Searches now happen 1 second after the user stops typing. This significantly reduces the number of requests.

The components Header and HeaderSearch were moved to the composition API, which is the recommended pattern by Vue.js.

Fixes #184

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Manual tests by searching the proposal name


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
