### PR TITLE
fix: rex logic and values

### DIFF
--- a/src/components/Rex/LiquidTab.vue
+++ b/src/components/Rex/LiquidTab.vue
@@ -29,6 +29,9 @@ export default defineComponent({
     const rexbal = computed(() => {
       return store.state.account.rexbal;
     });
+    const maturedRex = computed(() => {
+      return store.state?.account.maturedRex;
+    });
 
     function formatDec() {
       const precision = store.state.chain.token.precision;
@@ -102,7 +105,8 @@ export default defineComponent({
       assetToAmount,
       accountData,
       rexInfo,
-      rexbal
+      rexbal,
+      maturedRex
     };
   }
 });
@@ -124,8 +128,8 @@ export default defineComponent({
         .row
           .row.q-pb-sm.full-width
             .col-8 LIQUID TLOS TO WITHDRAW
-            .col-4.text-weight-bold.text-right {{rexbal.vote_stake ? rexbal.vote_stake : '0 TLOS'}}
-          q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' v-model="withdrawTokens" :lazy-rules='true' :rules="[ val => val >= 0  && val <= assetToAmount(rexbal.vote_stake)  || 'Invalid amount.' ]" type="text" dense dark)
+            .col-4.text-weight-bold.text-right {{maturedRex}}
+          q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' v-model="withdrawTokens" :lazy-rules='true' :rules="[ val => val >= 0  && val <= assetToAmount(maturedRex)  || 'Invalid amount.' ]" type="text" dense dark)
         .row
           q-btn.full-width.button-accent(label="Withdraw" flat @click="unstake" )
     ViewTransaction(:transactionId="transactionId" v-model="openTransaction" :transactionError="transactionError || ''" message="Transaction complete")

--- a/src/components/Rex/ProcessingTab.vue
+++ b/src/components/Rex/ProcessingTab.vue
@@ -17,17 +17,9 @@ export default defineComponent({
     const accountData = computed((): AccountDetails => {
       return store.state?.account.data;
     });
-
-    function assetToAmount(asset: string, decimals = -1): number {
-      try {
-        let qty: string = asset.split(' ')[0];
-        let val: number = parseFloat(qty);
-        if (decimals > -1) qty = val.toFixed(decimals);
-        return val;
-      } catch (error) {
-        return 0;
-      }
-    }
+    const maturingRex = computed(() => {
+      return store.state?.account.maturingRex;
+    });
 
     function refundProgress(): number {
       let diff =
@@ -64,13 +56,6 @@ export default defineComponent({
       }
     }
 
-    function maturingRex(): string {
-      const mature =
-        assetToAmount(accountData.value.account.rex_info?.vote_stake) -
-        assetToAmount(accountData.value.account.rex_info?.matured_rex);
-      return mature.toString() + ' TLOS';
-    }
-
     function component(x: number, v: number) {
       return Math.floor(x / v);
     }
@@ -98,13 +83,12 @@ export default defineComponent({
       .col-xs-12.col-sm-6
         .row.q-pa-sm
           .col-6 Rex maturing
-          .col-6.text-right.text-weight-bold {{maturingRex()}}
+          .col-6.text-right.text-weight-bold {{maturingRex}}
       .col-xs-12.col-sm-6
         .row.q-pa-sm
           .col-7 {{maturitiesCountdown()}}
           .col-5.text-right.text-weight-bold 
-            q-linear-progress( :value="refundProgress()" :buffer="buffer" color="grey-3" class="q-mt-sm")
-    ViewTransaction(:transactionId="transactionId" v-model="openTransaction" :transactionError="transactionError || ''" message="Transaction complete")
+            q-linear-progress( :value="refundProgress()" :buffer="0.5" color="grey-3" class="q-mt-sm")
 
 </template>
 

--- a/src/components/Rex/RexInfo.vue
+++ b/src/components/Rex/RexInfo.vue
@@ -19,27 +19,18 @@ export default defineComponent({
     const rexInfo = computed(() => {
       return store.state?.account.data.account.rex_info;
     });
-
-    function assetToAmount(asset: string, decimals = -1): number {
-      try {
-        let qty: string = asset.split(' ')[0];
-        let val: number = parseFloat(qty);
-        if (decimals > -1) qty = val.toFixed(decimals);
-        return val;
-      } catch (error) {
-        return 0;
-      }
-    }
-
-    function maturingRex(): string {
-      if (!rexInfo.value) {
-        return '0 TLOS';
-      }
-      const mature =
-        assetToAmount(rexInfo.value.vote_stake) -
-        assetToAmount(rexInfo.value.matured_rex);
-      return mature.toString() + 'TLOS';
-    }
+    const maturingRex = computed(() => {
+      return store.state?.account.maturingRex;
+    });
+    const coreRexBalance = computed(() => {
+      return store.state?.account.coreRexBalance;
+    });
+    const maturedRex = computed(() => {
+      return store.state?.account.maturedRex;
+    });
+    const rexSavings = computed(() => {
+      return store.state?.account.savingsRex;
+    });
 
     return {
       store,
@@ -48,7 +39,10 @@ export default defineComponent({
       accountData,
       token,
       maturingRex,
-      rexInfo
+      rexInfo,
+      coreRexBalance,
+      maturedRex,
+      rexSavings
     };
   }
 });
@@ -95,17 +89,17 @@ export default defineComponent({
       .col-xs-12.col-sm-6.q-px-lg
         .row
           .col-7 TOTAL TLOS IN REX
-          .col-5.text-right.text-weight-bold {{rexInfo ? rexInfo.vote_stake : '0 TLOS'}}
+          .col-5.text-right.text-weight-bold {{coreRexBalance}}
         .row.q-pt-sm
-          .col-7 REX BALANCE
-          .col-5.text-right.text-weight-bold {{rexInfo ? rexInfo.rex_balance : '0 TLOS'}}
+          .col-7 REX SAVINGS
+          .col-5.text-right.text-weight-bold {{rexSavings}}
       .col-xs-12.col-sm-6.q-px-lg
         .row
           .col-7 MATURED REX
-          .col-5.text-right.text-weight-bold {{rexInfo ? rexInfo.matured_rex : '0 TLOS'}}
+          .col-5.text-right.text-weight-bold {{maturedRex}}
         .row.q-pt-sm
           .col-7 MATURING REX
-          .col-5.text-right.text-weight-bold {{maturingRex()}}
+          .col-5.text-right.text-weight-bold {{maturingRex}}
 
 </template>
 

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -1,9 +1,4 @@
 <script lang="ts">
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { Action, PaginationSettings, TransactionTableRow } from 'src/types';
 import { defineComponent } from 'vue';
 import DateField from 'src/components/DateField.vue';
@@ -76,6 +71,7 @@ export default defineComponent({
   },
   watch: {
     async account() {
+      console.log(this.account);
       await this.loadTableData();
     }
   },
@@ -128,54 +124,54 @@ export default defineComponent({
 
 <template lang="pug">
 div.row.col-12.q-mt-xs.justify-center.text-left
-    div.row.col-11
-        div.row.col-12.q-mt-lg
-            div.col-3
-                p.panel-title {{ tableTitle }} 
-            q-space
-            div.col-3.row.flex.filter-buttons.temp-hide
-                q-btn.q-ml-xs.q-mr-xs.col.button-primary Actions
-                q-btn.q-ml-xs.q-mr-xs.col.button-primary Date
-                q-btn.q-ml-xs.q-mr-xs.col.button-primary Token
-        q-separator.row.col-12.q-mt-md.separator
-        div.row.col-12.table-container
-          q-table.q-mt-lg.row.fixed-layout(
-              :rows="rows"
-              :columns="columns"
-              row-key="name"
-              flat
-              :bordered="false"
-              :square="true"
-              table-header-class="table-header"
-              v-model:pagination="paginationSettings"
-              v-model:expanded="expanded"
-              :hide-pagination="!hasPages"
-              @update:expanded='updateExpanded'
-              )
-            template( v-slot:body-cell-transaction="props")
-              q-td( :props="props" )
-                AccountFormatter(:account="props.value.id" :type="props.value.type")
-            template( v-slot:body-cell-timestamp="props")
-              q-td( :props="props" )
-                DateField( :timestamp="props.value", showAge=true )
-            template( v-slot:body-cell-action="props")
-              q-td( :props="props" )
-                .row.justify-left.text-weight-light
-                  ActionFormatter(:action="props.value")
-            template( v-slot:body-cell-data="props")
-              q-td( :props="props"  )
-                DataFormatter(:actionData="props.value.data" :actionName="props.value.name ")
-            template( v-slot:pagination="scope")
-              div.row.col-12.q-mt-md.q-mb-xl()
-              div.col-1(align="left")
-                q-btn.q-ml-xs.q-mr-xs.col.button-primary(
-                  :disable="scope.isFirstPage"
-                  @click="scope.prevPage") PREV
-              q-space
-              div.col-1(align="right")
-                q-btn.q-ml-xs.q-mr-xs.col.button-primary(
-                  :disable="scope.isLastPage"
-                  @click="scope.nextPage") NEXT
+  div.row.col-11
+    div.row.col-12.q-mt-lg
+      div.col-3
+          p.panel-title {{ tableTitle }} 
+      q-space
+      div.col-3.row.flex.filter-buttons.temp-hide
+        q-btn.q-ml-xs.q-mr-xs.col.button-primary Actions
+        q-btn.q-ml-xs.q-mr-xs.col.button-primary Date
+        q-btn.q-ml-xs.q-mr-xs.col.button-primary Token
+    q-separator.row.col-12.q-mt-md.separator
+    div.row.col-12.table-container
+      q-table.q-mt-lg.row.fixed-layout(
+        :rows="rows"
+        :columns="columns"
+        row-key="name"
+        flat
+        :bordered="false"
+        :square="true"
+        table-header-class="table-header"
+        v-model:pagination="paginationSettings"
+        v-model:expanded="expanded"
+        :hide-pagination="!hasPages"
+        @update:expanded='updateExpanded'
+        )
+        template( v-slot:body-cell-transaction="props")
+          q-td( :props="props" )
+            AccountFormatter(:account="props.value.id" :type="props.value.type")
+        template( v-slot:body-cell-timestamp="props")
+          q-td( :props="props" )
+            DateField( :timestamp="props.value", :showAge='true' )
+        template( v-slot:body-cell-action="props")
+          q-td( :props="props" )
+            .row.justify-left.text-weight-light
+              ActionFormatter(:action="props.value")
+        template( v-slot:body-cell-data="props")
+          q-td( :props="props"  )
+            DataFormatter(:actionData="props.value.data" :actionName="props.value.name ")
+        template( v-slot:pagination="scope")
+          div.row.col-12.q-mt-md.q-mb-xl()
+          div.col-1(align="left")
+            q-btn.q-ml-xs.q-mr-xs.col.button-primary(
+              :disable="scope.isFirstPage"
+              @click="scope.prevPage") PREV
+          q-space
+          div.col-1(align="right")
+            q-btn.q-ml-xs.q-mr-xs.col.button-primary(
+              :disable="scope.isLastPage"
+              @click="scope.nextPage") NEXT
 </template>
 
 <style lang="sass">

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -24,7 +24,7 @@ export default defineComponent({
     const route = useRoute();
     const router = useRouter();
     const tab = ref<string>((route.query['tab'] as string) || 'transactions');
-    const account = computed(() => route.params.account as string);
+    const account = computed(() => (route.params.account as string) || '');
     const abi = computed(() => store.state.account.abi.abi);
 
     onMounted(async () => {

--- a/src/store/account/mutations.ts
+++ b/src/store/account/mutations.ts
@@ -25,8 +25,21 @@ export const mutations: MutationTree<AccountStateInterface> = {
   setRexActions(state: AccountStateInterface, actions: Action[]) {
     state.rexActions = actions;
   },
-  setRexbal(state: AccountStateInterface, rexbal: Rexbal) {
-    state.rexbal = rexbal;
+  setRexbal(
+    state: AccountStateInterface,
+    params: {
+      rexbal: Rexbal;
+      coreBalance: number;
+      maturingRex: number;
+      savingsRex: number;
+      maturedRex: number;
+    }
+  ) {
+    state.rexbal = params.rexbal;
+    state.coreRexBalance = params.coreBalance.toFixed(4) + ' TLOS';
+    state.maturedRex = params.maturedRex.toFixed(4) + ' TLOS';
+    state.maturingRex = params.maturingRex.toFixed(4) + ' TLOS';
+    state.savingsRex = params.savingsRex.toFixed(4) + ' TLOS';
   },
   setVote(state: AccountStateInterface, vote: string[]) {
     state.vote = vote.sort();

--- a/src/store/account/state.ts
+++ b/src/store/account/state.ts
@@ -14,6 +14,10 @@ export interface AccountStateInterface {
   rexbal: Rexbal;
   vote: string[];
   abi: ABI;
+  coreRexBalance: string;
+  maturingRex: string;
+  maturedRex: string;
+  savingsRex: string;
 }
 
 export function state(): AccountStateInterface {
@@ -30,6 +34,10 @@ export function state(): AccountStateInterface {
     TransactionError: '',
     rexbal: {} as Rexbal,
     vote: [],
-    abi: { abi: null } as ABI
+    abi: { abi: null } as ABI,
+    coreRexBalance: '0 TLOS',
+    maturingRex: '0 TLOS',
+    maturedRex: '0 TLOS',
+    savingsRex: '0 TLOS'
   };
 }

--- a/src/types/TableRows.ts
+++ b/src/types/TableRows.ts
@@ -43,3 +43,18 @@ export interface Producer {
 export interface ProducerRows {
   rows: Producer[];
 }
+
+export interface RexPoolRows {
+  rows: RexPool[];
+}
+
+export interface RexPool {
+  loan_num: number;
+  namebid_proceeds: string;
+  total_lendable: string;
+  total_lent: string;
+  total_rent: string;
+  total_rex: string;
+  total_unlent: string;
+  version: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,14 @@ export { GenericObj } from './GenericObj';
 export { Transaction } from './Transaction';
 export { OptionsObj } from './OptionsObj';
 export { TreeNode } from './TreeNode';
-export { RexbalRows, Rexbal, ProducerRows, GenericTable } from './TableRows';
+export {
+  RexbalRows,
+  Rexbal,
+  ProducerRows,
+  GenericTable,
+  RexPoolRows,
+  RexPool
+} from './TableRows';
 export { BP } from './BP';
 export { ChainInfo } from './ChainInfo';
 export { ProducerSchedule } from './ProducerSchedule';


### PR DESCRIPTION
# Pull Request Template

## Description

Not sure if the initial issue is fixed.
Calculated the accounts [RexValue in TLOS](https://github.com/telosnetwork/open-block-explorer/blob/213-bug-account-rex-value-should-include-earnings/src/store/account/actions.ts#L68-L69) by taking the eosio rexbal rex_balance value and getting the telos value by multiplying with totalLendable/totalRex. But that just gave me the same value as the accounts rex_info>vote_stake. And this is what I used initially as total TLOS in rex.

did make some other changes though. 
![image](https://user-images.githubusercontent.com/41372145/181263365-49a37809-7c53-4775-886f-298e210f6c5f.png)
Rex savings, matured and maturing can be seen correctly and together amount to the total TLOS in rex.

Also fixed the liquid ttlos to withdraw to the matures rex amount and not to the total tlos amount.
![image](https://user-images.githubusercontent.com/41372145/181264156-854001fd-5182-4aab-8fea-b7c51bca56d1.png)

Processing tab also shows correct maturing values now.
![image](https://user-images.githubusercontent.com/41372145/181264665-697fdd40-e20a-4604-82e7-884f7cd1958b.png)
vs actual
![image](https://user-images.githubusercontent.com/41372145/181264741-4d39f585-40d9-4b5c-b0be-1f199909ef3f.png)

@DonaldPeat @poplexity please check my calculations [here](https://github.com/telosnetwork/open-block-explorer/blob/213-bug-account-rex-value-should-include-earnings/src/store/account/actions.ts#L60-L87) to make sure they are correct.


Fixes #213 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
