### PR TITLE
265 bug unlend rex fails due to using tlos amount as rex amount

### DIFF
--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -64,26 +64,26 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         : 0;
     const totalRex = Number(rexpool.total_rex.split(' ')[0]);
     const totalLendable = Number(rexpool.total_lendable.split(' ')[0]);
-    const rexTlosRatio = totalRex > 0 ? totalLendable / totalRex : 1;
-    const coreBalance =
-      totalRex > 0 ? (totalLendable / totalRex) * rexBalance : 0;
+    const tlosRexRatio = totalRex > 0 ? totalLendable / totalRex : 1;
+    commit('setTlosRexRatio', tlosRexRatio);
+    const coreBalance = totalRex > 0 ? tlosRexRatio * rexBalance : 0;
 
     const maturingRex = rexbal
       ? rexbal.rex_maturities &&
         rexbal.rex_maturities[0] &&
         rexbal.rex_maturities[0].second &&
-        rexTlosRatio * (Number(rexbal.rex_maturities[0].second) / 10000)
+        tlosRexRatio * (Number(rexbal.rex_maturities[0].second) / 10000)
       : 0;
 
     const savingsRex = rexbal
       ? rexbal.rex_maturities &&
         rexbal.rex_maturities[1] &&
         rexbal.rex_maturities[1].second &&
-        rexTlosRatio * (Number(rexbal.rex_maturities[1].second) / 10000)
+        tlosRexRatio * (Number(rexbal.rex_maturities[1].second) / 10000)
       : 0;
 
     const maturedRex = rexbal
-      ? rexTlosRatio * (Number(rexbal.matured_rex) / 10000)
+      ? tlosRexRatio * (Number(rexbal.matured_rex) / 10000)
       : 0;
     if (rexbalRows.rows.length > 0) {
       commit('setRexbal', {
@@ -190,12 +190,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     const authenticators = ual().getAuthenticators().availableAuthenticators;
     const user = (await authenticators[0].login())[0];
     const quantityStr = `${Number(amount).toFixed(4)} TLOS`;
-    const accountInfo = state.data.account.rex_info;
-    const totalRex = state.data.account.rex_info
-      ? Number(accountInfo.rex_balance.split(' ')[0])
-      : 0;
-    const portionToUnstake = Number(amount) / tokenRexBalance;
-    const rexToUnstake = (totalRex * portionToUnstake).toFixed(4);
+    const rexToUnstake = (Number(amount) / state.tlosRexRatio).toFixed(4);
 
     //   TODO check maturities
     const actions = [

--- a/src/store/account/mutations.ts
+++ b/src/store/account/mutations.ts
@@ -46,5 +46,8 @@ export const mutations: MutationTree<AccountStateInterface> = {
   },
   setABI(state: AccountStateInterface, abi: ABI) {
     state.abi = abi;
+  },
+  setTlosRexRatio(state: AccountStateInterface, ratio: number) {
+    state.tlosRexRatio = ratio;
   }
 };

--- a/src/store/account/state.ts
+++ b/src/store/account/state.ts
@@ -18,6 +18,7 @@ export interface AccountStateInterface {
   maturingRex: string;
   maturedRex: string;
   savingsRex: string;
+  tlosRexRatio: number;
 }
 
 export function state(): AccountStateInterface {
@@ -38,6 +39,7 @@ export function state(): AccountStateInterface {
     coreRexBalance: '0 TLOS',
     maturingRex: '0 TLOS',
     maturedRex: '0 TLOS',
-    savingsRex: '0 TLOS'
+    savingsRex: '0 TLOS',
+    tlosRexRatio: 1
   };
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed the amount of REX to unstake value. It was giving the tlos amount and not the correct rex amount

Fixes #265 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
