### PR TITLE
Showing better BP msig information

### DIFF
--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -249,3 +249,11 @@ export const getKeyAccounts = async function (
 
   return response.data;
 };
+
+export const getProducerSchedule = async function (): Promise<{
+  active: { producers: { producer_name: string }[] };
+}> {
+  const response = await hyperion.get('v1/chain/get_producer_schedule');
+
+  return response.data;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,7 +21,8 @@ import {
   getProposals,
   getProducers,
   getABI,
-  getKeyAccounts
+  getKeyAccounts,
+  getProducerSchedule
 } from './hyperion'; //  e.g. './new-service' method name stays the same
 import {
   getTableRows,
@@ -51,5 +52,6 @@ export const api = {
   getABI,
   getKeyAccounts,
   deserializeActionData,
-  serializeActionData
+  serializeActionData,
+  getProducerSchedule
 };

--- a/src/components/ProposalTable.vue
+++ b/src/components/ProposalTable.vue
@@ -9,7 +9,7 @@ q-table(
   :rows="rows"
   :columns="columns"
   row-key="proposalName"
-  :rows-per-page-options="[5,10,20,40,80,160]"
+  :rows-per-page-options="[20,40,80,160]"
   v-model:pagination="pagination"
   @request="onRequest"
 )
@@ -43,7 +43,7 @@ q-table(
                     q-item-section No results
 
             div.q-pr-md.q-pb-md
-              q-toggle(label="Already executed" v-model="isExecuted")
+              q-toggle(label="Inactive proposals" v-model="isExecuted")
 
   template(v-slot:no-data)
     span.q-pa-md.full-width.text-center.text-body2.
@@ -83,8 +83,8 @@ const initialStatePagination = {
   sortBy: 'desc',
   descending: false,
   page: 1,
-  rowsPerPage: 5,
-  rowsNumber: 5
+  rowsPerPage: 20,
+  rowsNumber: 20
 };
 
 export default defineComponent({
@@ -140,12 +140,6 @@ export default defineComponent({
         align: 'left',
         label: 'PROPOSER',
         field: 'proposer'
-      },
-      {
-        name: 'executed',
-        align: 'left',
-        label: 'EXECUTED',
-        field: 'executed'
       }
     ];
 
@@ -196,8 +190,7 @@ export default defineComponent({
             primaryKey: proposal.primary_key,
             proposalName: proposal.proposal_name,
             approvalStatus,
-            proposer: proposal.proposer,
-            executed: proposal.executed
+            proposer: proposal.proposer
           };
         });
       } catch (e) {

--- a/src/types/Proposal.ts
+++ b/src/types/Proposal.ts
@@ -74,5 +74,5 @@ export interface RequestedApprovals {
   actor: string;
   permission: string;
   status: boolean;
-  index: number;
+  isBp: boolean;
 }


### PR DESCRIPTION
## Description
- Label `Active BP` beside each active BP
- Lists the number of active BPs approvals right next to the overall number
- Approvals are listed:
    - Active BPs that have approved 
    - Active BP's that **haven't** approved
    - Standby BPs + accounts that have approved
    - Standby BPs + accounts that **haven't** approved
- Removes executed/not executed from the `/proposals` table. The filter indicates if a proposal has reached a final state or not. A cancelled proposal would be marked as executed, so to avoid misleading information, we removed the column. To add the cancelled information to the list, we would need to make additional requests and the current filter is sufficient to show the active proposals and the ones that are not anymore.
- Increases to 20 items per page by default for proposals
- Shows 25 approvals so all BPs are shown in the first page

Fixes #262 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
- Manual tests with proposals from mainnet

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
