### PR TITLE
Rex savings fixes

### DIFF
--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -52,8 +52,7 @@ export default defineComponent({
       if (
         toSavingAmount.value === '0.0000' ||
         toSavingAmount.value === '' ||
-        Number(toSavingAmount.value) >=
-          assetToAmount(accountData.value.account.total_resources.cpu_weight)
+        Number(toSavingAmount.value) >= assetToAmount(maturedRex.value)
       ) {
         return;
       }
@@ -68,8 +67,7 @@ export default defineComponent({
       if (
         fromSavingAmount.value === '0.0000' ||
         fromSavingAmount.value === '' ||
-        Number(fromSavingAmount.value) >=
-          assetToAmount(accountData.value.account.total_resources.cpu_weight)
+        Number(fromSavingAmount.value) >= assetToAmount(rexSavings.value)
       ) {
         return;
       }

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -92,28 +92,27 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     commit('setTlosRexRatio', tlosRexRatio);
     const coreBalance = totalRex > 0 ? tlosRexRatio * rexBalance : 0;
 
-    const maturingRex = rexbal
-      ? rexbal.rex_maturities &&
-        rexbal.rex_maturities[0] &&
-        new Date(rexbal.rex_maturities[0].first).getFullYear() -
-          new Date().getFullYear() <=
-          1 &&
-        tlosRexRatio * (Number(rexbal.rex_maturities[0].second) / 10000)
-      : 0;
     let savingsRex = 0;
+    let maturedRex = rexbal
+      ? tlosRexRatio * (Number(rexbal.matured_rex) / 10000)
+      : 0;
+    let maturingRex = 0;
     if (rexbal && rexbal.rex_maturities && rexbal.rex_maturities.length > 0) {
       const thisYear = new Date().getFullYear();
+      const now = new Date().getTime();
       rexbal.rex_maturities.forEach((maturity) => {
         const maturityYear = new Date(maturity.first).getFullYear();
+        const maturityTime = new Date(maturity.first).getTime();
         if (maturityYear - thisYear > 1) {
           savingsRex = tlosRexRatio * (Number(maturity.second) / 10000);
+        } else if (maturityTime - now < 0) {
+          maturedRex += tlosRexRatio * (Number(maturity.second) / 10000);
+        } else {
+          maturingRex = tlosRexRatio * (Number(maturity.second) / 10000);
         }
       });
     }
 
-    const maturedRex = rexbal
-      ? tlosRexRatio * (Number(rexbal.matured_rex) / 10000)
-      : 0;
     if (rexbalRows.rows.length > 0) {
       commit('setRexbal', {
         rexbal: rexbalRows.rows[0],


### PR DESCRIPTION
# Pull Request Template

## Description

Savings validation used the wrong value. Saving maturing and matured account values issue fixed.
Maturing rex value shows even though the date has expired. Added some date checks.

- An expired date value now gets added to total matured.
- A date difference greater that a year will now be seen as the account savings value.
- Everything else will be maturing rex.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
