### PR TITLE
379 bug voting tlos amount incorrect

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -124,21 +124,23 @@ export default defineComponent({
       net_max.value = fixDec(account.net_limit.max / KILO_UNIT.value);
       liquid.value = getAmount(account.core_liquid_balance);
       liqNum.value = getAmount(account.core_liquid_balance);
-      resources.value = account?.total_resources
-        ? Number(account.total_resources.cpu_weight.split(' ')[0]) +
-          Number(account.total_resources.net_weight.split(' ')[0])
+      resources.value = account?.self_delegated_bandwidth
+        ? Number(account.self_delegated_bandwidth.cpu_weight.split(' ')[0]) +
+          Number(account.self_delegated_bandwidth.net_weight.split(' ')[0])
         : 0;
+      const delegatedNum =
+        Number(account.total_resources.cpu_weight.split(' ')[0]) +
+        Number(account.total_resources.net_weight.split(' ')[0]) -
+        Number(
+          account?.self_delegated_bandwidth?.net_weight.split(' ')[0] || 0
+        ) -
+        Number(
+          account?.self_delegated_bandwidth?.cpu_weight.split(' ')[0] || 0
+        );
       delegatedResources.value = account?.total_resources
-        ? (
-            Number(account.total_resources.cpu_weight.split(' ')[0]) +
-            Number(account.total_resources.net_weight.split(' ')[0]) -
-            Number(
-              account?.self_delegated_bandwidth?.net_weight.split(' ')[0] || 0
-            ) -
-            Number(
-              account?.self_delegated_bandwidth?.cpu_weight.split(' ')[0] || 0
-            )
-          ).toFixed(token.value.precision) + ` ${token.value.symbol}`
+        ? (delegatedNum > 0 ? delegatedNum : 0.0).toFixed(
+            token.value.precision
+          ) + ` ${token.value.symbol}`
         : `${token.value.symbol}`;
       if (account.rex_info) {
         const liqNum = account.core_liquid_balance.split(' ')[0];
@@ -218,7 +220,9 @@ export default defineComponent({
       if (token.value.symbol === '') {
         const tokenList = await api.getTokens(system_account.value);
         const token = tokenList.find(
-          (token: Token) => token.contract === `${system_account.value}.token`
+          (token: Token) =>
+            token.contract === `${system_account.value}.token` &&
+            token.symbol === chain.getSymbol()
         );
         setToken(token);
       }

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -152,7 +152,6 @@ export default defineComponent({
       } else {
         total.value = liquid.value;
       }
-      console.log('here');
       refunding.value = formatTotalRefund(account.refund_request);
       staked.value = account.voter_info
         ? formatStaked(account.voter_info.staked)

--- a/src/components/Resources/ResourcesInfo.vue
+++ b/src/components/Resources/ResourcesInfo.vue
@@ -40,14 +40,18 @@ export default defineComponent({
           )[0]
         ) -
         Number(
-          store.state.account.data.account.self_delegated_bandwidth.net_weight.split(
-            ' '
-          )[0]
+          store.state.account.data.account?.self_delegated_bandwidth?.net_weight
+            ? store.state.account.data.account.self_delegated_bandwidth.net_weight.split(
+                ' '
+              )[0]
+            : '0'
         ) -
         Number(
-          store.state.account.data.account.self_delegated_bandwidth.cpu_weight.split(
-            ' '
-          )[0]
+          store.state.account.data.account?.self_delegated_bandwidth?.cpu_weight
+            ? store.state.account.data.account.self_delegated_bandwidth.cpu_weight.split(
+                ' '
+              )[0]
+            : '0'
         )
       );
     });

--- a/src/components/Staking/StakingDialog.vue
+++ b/src/components/Staking/StakingDialog.vue
@@ -50,8 +50,11 @@ export default defineComponent({
     const transactionId = ref<string>(null);
     const transactionError = ref<string>(null);
 
-    const withdrawRexFund = () => {
-      void store.dispatch('account/unstakeRexFund', { amount: rexfund.value });
+    const withdrawRexFund = async () => {
+      await store.dispatch('account/unstakeRexFund', { amount: rexfund.value });
+      void store.dispatch('account/updateRexData', {
+        account: store.state.account.accountName
+      });
     };
     return {
       openCoinDialog: ref<boolean>(false),
@@ -142,7 +145,7 @@ q-dialog( @show='setDefaults' :persistent='true' @hide='resetForm' maximized)
           StakingInfo
           .q-pt-lg.q-pl-lg(v-if='rexfund > 0')
             .row.q-col-gutter-md.items-center
-              .col-auto.text-h6.text-white REX fund: {{rexfund}} {{symbol}}
+              .col-auto.text-h6.text-white REX fund: {{rexfund.toFixed(4)}} {{symbol}}
               .col-auto
                 q-btn.full-width.button-accent(label='Withdraw' flat @click="withdrawRexFund" )
           .q-pt-lg.text-grey-3.text-weight-light

--- a/src/components/validators/ValidatorData.vue
+++ b/src/components/validators/ValidatorData.vue
@@ -27,7 +27,9 @@ export default defineComponent({
     const balance = computed(
       () =>
         (Number(
-          store.state.account.data?.account?.voter_info.last_vote_weight
+          store.state.account.data?.account?.voter_info?.last_stake
+            ? store.state.account.data?.account.voter_info.last_stake / 10000
+            : 0
         ).toFixed(2) || '0') + ` ${symbol}`
     );
     const activecount = computed(() => {
@@ -70,9 +72,11 @@ export default defineComponent({
         const voterInfo = data.account.voter_info;
         if (!voterInfo) return;
         producerVotes.value = voterInfo?.producers;
-        lastWeight.value = parseFloat(voterInfo.last_vote_weight).toFixed(2);
-        lastStaked.value = voterInfo.last_stake;
-        stakedAmount.value = voterInfo.staked;
+        lastWeight.value = parseFloat(
+          voterInfo?.last_vote_weight || '0.0000'
+        ).toFixed(2);
+        lastStaked.value = voterInfo?.last_stake || 0.0;
+        stakedAmount.value = voterInfo.staked || 0.0;
       }
     }
     function assetToAmount(asset: string, decimals = -1): number {


### PR DESCRIPTION
# Fixes #379
# Fixes #377
# Fixes #372
# Fixes #359

## Description

Fixed multiple issues.

- Voting TLOS now uses last_stake value instead of last_vote_weight
![image](https://user-images.githubusercontent.com/41372145/197840249-aaaa3706-bc05-46d8-afa6-ec3d0966f6b1.png)
- Exclude delegated resources from account total
- refresh balance when done doing withdraw rexfund
- issue with null value self delegated resources fixed

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:

-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
