### PR TITLE
fix: remove non existing producers from voting list

### DIFF
--- a/src/components/validators/ValidatorDataTable.vue
+++ b/src/components/validators/ValidatorDataTable.vue
@@ -26,11 +26,19 @@ export default defineComponent({
     const query = route.query;
     const symbol = chain.getSymbol();
     const account = computed(() => store.state.account.accountName);
+    const producers = computed(() =>
+      [...store.state.chain.producers].map((val) => val.owner)
+    );
     const currentVote = computed(() => {
-      let votes = store.state.account.vote;
+      let votes = [...store.state.account.vote];
       if (query['vote']) {
         return votes.concat(query['vote'] as string);
       }
+      votes.forEach((vote, index) => {
+        if (!producers.value.includes(vote)) {
+          votes.splice(index, 1);
+        }
+      });
       return votes;
     });
     const selection = ref<string[]>([]);
@@ -94,6 +102,11 @@ export default defineComponent({
     }
 
     function updateVote(val: string[]) {
+      val.forEach((vote, index) => {
+        if (!producers.value.includes(vote)) {
+          val.splice(index, 1);
+        }
+      });
       store.commit('account/setVote', val);
     }
 


### PR DESCRIPTION
# Fixes #358 

## Description

Clean voting list of all non active BPs on vote change.

## Test scenarios

Added random non existing BP to array and checked that it got removed.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
