### PR TITLE
fix: sign the transaction with correct permission

### DIFF
--- a/src/boot/ual.ts
+++ b/src/boot/ual.ts
@@ -78,7 +78,8 @@ export default boot(({ app }) => {
     }
     return {
       accountName,
-      permission
+      permission,
+      requestPermission: permission
     };
   }
 

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -31,7 +31,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
       const account = users[0];
       const permission = (account as unknown as { requestPermission: string })
         .requestPermission;
-      commit('setAccountPermission', permission);
+      commit('setAccountPermission', permission || 'active');
       const accountName = await account.getAccountName();
       commit('setUser', account);
       commit('setIsAuthenticated', true);
@@ -157,7 +157,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: data as unknown
@@ -188,7 +188,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -202,7 +202,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -245,7 +245,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -259,7 +259,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -294,7 +294,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -329,7 +329,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -366,7 +366,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -443,7 +443,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -580,7 +580,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {
@@ -615,7 +615,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         authorization: [
           {
             actor: state.accountName,
-            permission: 'active'
+            permission: state.accountPermission
           }
         ],
         data: {


### PR DESCRIPTION
# Fixes #244 

## Description

Sign transactions with the correct permission instead of defaulting to 'active'.


## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
