### PR TITLE
fix: add proposal name validation and add a tooltip with instructions…

### DIFF
--- a/src/pages/ProposalNew.vue
+++ b/src/pages/ProposalNew.vue
@@ -32,7 +32,16 @@ q-page(padding)
               v-model="formData.proposal_name"
               label="Proposal Name"
               maxlength="13"
-              :rules="[value => !!value || 'Field is required']")
+              :rules="[value => !!value || 'Field is required', value=> /(^[a-z1-5.]{1,11}[a-z1-5]$)|(^[a-z1-5.]{12}[a-j1-5]$)/.test(value) || 'Must be up to 12 characters (a-z, 1-5, .) and cannot end with a .']")
+                template(#append)
+                  q-icon(name="info")
+                  q-tooltip.text-body2
+                    ul.q-px-lg.q-py-none
+                      li Minimum of 2 characters
+                      li Maximum of 13 characters
+                      li First 12 characters can be “a-z” or “1-5" or “.”
+                      li 13th character can only be “a-j” or “1-5”
+                      li Last character can not be “.”
           div.col-12.col-sm-6
             q-input(
               outlined


### PR DESCRIPTION
# Fixes #386 

## Description
<!---
Include a summary of your change and how it solves the issue its related to
-->
This PR adds antelope name validation to the name input for proposals

## Test scenarios
<!---
Describe the test scenarios that you ran to verify your changes.
Please include any relevant configuration required to reproduce them.
-->
- Using the input to insert names that don't follow the naming constraints of antelope account name

## Checklist:
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
