### PR TITLE
Fix search result selection redirect

### DIFF
--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -181,7 +181,6 @@ export default defineComponent({
               account: inputValue.value.toLowerCase()
             }
           });
-          debugger;
           router.go(0);
           return;
         } catch (error) {


### PR DESCRIPTION
# Fixes #246 

## Test scenarios
- search for 'stlos' (should see an account and a proposal with same name listed)
- clicking the result under account should redirect to /account page
- clicking the result under 'Proposals' should redirect to the /proposal page
- enter 'stlos' and click 'Enter', should default to account page
- enter 'EOS54X5EiXQRn6gtGhR5vHMRyvZyBtvxV1MsqAdY1nRhc3sUpAjLG' in search bar and click 'Enter', should redirect to /key page
- enter '887ba18e5e9713900885df64da27e52e98deebf7d2c93de4421759f29c57b991' in search bar and click 'Enter', should redirect to /transaction page
- clear search input, click 'Enter', should do nothing
- enter gibberish >13 characters and <53 characters, should show 'no results found' in dropdown and not redirect

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
