### PR TITLE
fix: regex to ignore trailing and leading spaces and periods

### DIFF
--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -38,7 +38,11 @@ export default defineComponent({
 
     watch(waitToSearch, async (currentValue) => {
       if (!currentValue) {
-        const queryValue = inputValue.value.toLowerCase();
+        const queryValue = inputValue.value
+          .toLowerCase()
+          // remove leading and trailing spaces and periods from search input
+          .replace(/^[\s.]+|[\s.]+$/g, '');
+
         options.value = [];
 
         await Promise.all([


### PR DESCRIPTION
# Fixes #391 

## Description
added regex to remove trailing and leading spaces and periods from input used for query. filters results based on original input

## Test scenarios
- search `rng.`, see `rng.oracle` result (previously generated error/no results)
 
## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
