### PR TITLE
fix: enter triggers search on contract table

### DIFF
--- a/src/components/contract/ContractTables.vue
+++ b/src/components/contract/ContractTables.vue
@@ -120,16 +120,16 @@ q-card(
     .row.q-py-md.q-col-gutter-md
       .col-xs-6.col-sm-3
         .text-bold.q-pb-sm Scope
-        q-input(outlined @blur="getRows"  dense v-model="scope" style="background: #ffffff")
+        q-input(outlined @keydown.enter.prevent="getRows" @blur="getRows"  dense v-model="scope" style="background: #ffffff")
       .col-xs-6.col-sm-3
         .text-bold.q-pb-sm Lower Bound
-        q-input(outlined @blur="getRows" v-model="lower" dense style="background: #ffffff")
+        q-input(outlined @keydown.enter.prevent="getRows" @blur="getRows" v-model="lower" dense style="background: #ffffff")
       .col-xs-6.col-sm-3
         .text-bold.q-pb-sm Upper Bound
-        q-input(outlined @blur="getRows" v-model="upper" dense style="background: #ffffff")
+        q-input(outlined @keydown.enter.prevent="getRows" @blur="getRows" v-model="upper" dense style="background: #ffffff")
       .col-xs-6.col-sm-3
         .text-bold.q-pb-sm Limit
-        q-input(outlined @blur="getRows" v-model="limit" dense style="background: #ffffff")
+        q-input(outlined @keydown.enter.prevent="getRows" @blur="getRows" v-model="limit" dense style="background: #ffffff")
 
   q-card-section.q-pt-none
     q-table(


### PR DESCRIPTION
# Fixes #issue_number

## Description

On the contract table pressing enter will now refresh the table on all filters.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
