### PR TITLE
fix: block num not showing

### DIFF
--- a/src/components/Transaction/AccountFormat.vue
+++ b/src/components/Transaction/AccountFormat.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'AccountFormat',
@@ -14,9 +14,10 @@ export default defineComponent({
     }
   },
   setup(props) {
+    const accAccount = computed(() => props.account);
     return {
       accType: props.type,
-      accAccount: props.account
+      accAccount
     };
   }
 });


### PR DESCRIPTION
# Fixes #463 

## Description

Fixed block number not showing on transaction card.
![image](https://user-images.githubusercontent.com/41372145/204732808-c858b424-9b07-4657-8ba6-b6ef80924034.png)


## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
