### PR TITLE
on the account page the ability to filter tokens

### DIFF
--- a/src/components/TokensPanel.vue
+++ b/src/components/TokensPanel.vue
@@ -15,10 +15,34 @@ export default defineComponent({
     const tokens = ref<Token[]>([]);
     const account = toRef(props, 'account');
 
+    const getURLFilters = (name: string): string[] => {
+      // TODO: change this implementation and use this.$route
+      const queryString = window.location.search;
+      const urlParams = new URLSearchParams(queryString);
+      if (urlParams.has(name)) {
+        return urlParams.get(name).split(',');
+      } else {
+        return [];
+      }
+    };
+
     const loadTokens = async (): Promise<void> => {
       // TODO Refactor redundant getTokens in AccountCard
       const tokenList = await api.getTokens(account.value);
-      tokens.value = tokenList.map(
+
+      const codes = getURLFilters('code');
+      const symbols = getURLFilters('symbol');
+      let filtered = tokenList
+        .filter(
+          (token: Token) =>
+            codes.length === 0 || codes.some((c) => c == token.contract)
+        )
+        .filter(
+          (token: Token) =>
+            symbols.length === 0 || symbols.some((c) => c == token.symbol)
+        );
+
+      tokens.value = filtered.map(
         (token) =>
           ({
             symbol: token.symbol,
@@ -27,6 +51,7 @@ export default defineComponent({
             contract: formatAccount(token.contract, 'account')
           } as Token)
       );
+
       tokens.value = tokens.value.filter(
         (token) => (token as Token).amount !== null
       );


### PR DESCRIPTION
# Fixes #395
It is desirable to be able to filter the tokens shown on the account page as requested in #395. 

## Description
In order to do that, the URL parameters were used to filter the list of tokens displayed. If the URL parameters are used, only the tokens matching the parameters will be shown. Otherwise, all account tokens are displayed.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
