### PR TITLE
Transaction table paging issue

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -102,9 +102,14 @@ export default defineComponent({
       isTransaction.value ? 'Actions' : 'Latest Transactions'
     );
 
-    const hasPages = computed(
-      () => rows.value.length >= paginationSettings.value.rowsPerPage
-    );
+    const hasPages = computed(() => {
+      let count = 0;
+      rows.value.forEach((element: TransactionTableRow) => {
+        count += element.actions.length;
+      });
+      return count >= paginationSettings.value.rowsPerPage;
+    });
+    
     const noData = computed(() => rows.value.length === 0);
     const hasActions = computed(() => actions.value != null);
     const filter = computed(() => {

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -109,7 +109,7 @@ export default defineComponent({
       });
       return count >= paginationSettings.value.rowsPerPage;
     });
-    
+
     const noData = computed(() => rows.value.length === 0);
     const hasActions = computed(() => actions.value != null);
     const filter = computed(() => {


### PR DESCRIPTION
# Fixes 

## Description

Transaction table has broken next button because of the grouping of transactions.
Reason is that the row amount is not greater or equal than the page * rows_per_page cauing the table to think there are no more values to load.
Fixed this by counting all the grouped transactions.


## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
