### PR TITLE
fix: remove persistent date dropdown

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -294,7 +294,6 @@ div.row.col-12.q-mt-xs.justify-center.text-left
             .row
               q-input(filled dense v-model='actionsFilter' label="Search")
         q-btn-dropdown.q-ml-xs.q-mr-xs.col.button-primary(
-          persistent
           color="primary"
           label="Date")
           .q-pa-md.dropdown-filter


### PR DESCRIPTION
# Fixes #433

## Description

Date dropdown  filter for transactiontable closes when losing focus.


## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
