### PR TITLE
repairing the REX balance calculation

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -93,7 +93,6 @@ export default defineComponent({
       store.commit('chain/setToken', value);
     };
     const loadAccountData = async (): Promise<void> => {
-      void updateRexBalance();
       let data: AccountDetails;
       try {
         data = await api.getAccount(props.account);
@@ -151,15 +150,14 @@ export default defineComponent({
           token.value.precision
         );
         total.value = `${totalString} ${token.value.symbol}`;
-        rex.value = account.rex_info.vote_stake;
       } else {
         total.value = liquid.value;
-        rex.value = none.value;
       }
       refunding.value = formatTotalRefund(account.refund_request);
       staked.value = account.voter_info
         ? formatStaked(account.voter_info.staked)
         : none.value + ` ${token.value.symbol}`;
+      void updateRexBalance();
     };
     const updateRexBalance = async () => {
       const paramsrexbal = {


### PR DESCRIPTION
# Fixes #479 

## Description
indeed, there were two different solutions calculating the same REX balance (one was badly implemented) and they were running always in parallel (but not always they end the same way). When the bad implementation ended first, it was overwritten with the good one and vice-versa. So, the final result was always unpredictable.

The bad solutions were removed and the good implementation now is launched always at the end, so it writes the good result.

Note: this is a quick patch to solve the inconsistency bug, but this code needs a big refactoring.

## Test scenarios
Refreshing several times and checking the total balances is always the same.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
