### PR TITLE
447 should use nodeos for getting key accounts

### DIFF
--- a/src/api/eosio_core.ts
+++ b/src/api/eosio_core.ts
@@ -9,7 +9,9 @@ import {
   Action,
   ActionType,
   APIClient,
-  Serializer
+  Serializer,
+  PublicKey,
+  Name
 } from '@greymass/eosio';
 import { ActionData, GetTableRowsParams } from 'src/types';
 import { Chain } from 'src/types/Chain';
@@ -25,6 +27,13 @@ export const getAccount = async function (
   address: string
 ): Promise<API.v1.AccountObject> {
   return await eosioCore.v1.chain.get_account(address);
+};
+
+export const getKeyAccounts = async function (
+  key: PublicKey
+): Promise<{ account_names: Name[] }> {
+  const response = await eosioCore.v1.history.get_key_accounts(key);
+  return response;
 };
 
 export const getTokenBalances = async function (

--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -238,7 +238,7 @@ export const getABI = async function (account: string): Promise<ABI> {
   return response.data;
 };
 
-export const getKeyAccounts = async function (
+export const getHyperionKeyAccounts = async function (
   key: string
 ): Promise<{ account_names: string[] }> {
   const response = await hyperion.get('v2/state/get_key_accounts', {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -37,6 +37,7 @@ import { getApy } from './telosApi';
 
 export const api = {
   getAccount,
+  getKeyAccounts,
   getHyperionAccountData,
   getCreator,
   getTokens,
@@ -55,7 +56,6 @@ export const api = {
   getProposals,
   getProducers,
   getABI,
-  getKeyAccounts,
   deserializeActionData,
   serializeActionData,
   getProducerSchedule,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,12 +21,12 @@ import {
   getProposals,
   getProducers,
   getABI,
-  getKeyAccounts,
   getProducerSchedule
 } from './hyperion'; //  e.g. './new-service' method name stays the same
 
 import {
   getAccount,
+  getKeyAccounts,
   getTableRows,
   getTokenBalances,
   deserializeActionData,

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -121,7 +121,6 @@ export default defineComponent({
       } catch (e) {
         $q.notify(`account ${props.account} not found!`);
         accountExists.value = false;
-        console.log(e);
         return;
       }
     };

--- a/src/components/KeyAccountsCard.vue
+++ b/src/components/KeyAccountsCard.vue
@@ -2,26 +2,32 @@
 import { useQuasar } from 'quasar';
 import { defineComponent, PropType, computed, ref } from 'vue';
 import { copyToClipboard } from 'quasar';
-import { Numeric } from 'eosjs';
 import { getChain } from 'src/config/ConfigManager';
+import { Name, PublicKey } from '@greymass/eosio';
 
 export default defineComponent({
   name: 'KeyAccountsCard',
   props: {
-    pubkey: {
-      type: String as PropType<string>,
+    pubKey: {
+      type: PublicKey,
       required: true
     },
     accounts: {
-      type: Array as PropType<string[]>,
+      type: Array as PropType<Name[]>,
       required: true
     }
   },
   setup(props) {
     const chain = getChain();
-    const Key = ref(props.pubkey);
+    const key = ref(props.pubKey);
+    const legacyKeyFormat = ref<boolean>(false);
     const Accounts = computed(() => props.accounts);
     const $q = useQuasar();
+    const keyDisplay = computed(() => {
+      return legacyKeyFormat.value
+        ? key.value.toLegacyString()
+        : key.value.toString();
+    });
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     const tokenLogo = computed(() => chain.getSmallLogoPath());
     function copy(value: string) {
@@ -44,17 +50,12 @@ export default defineComponent({
         });
     }
     function toggleKey() {
-      if (Key.value.startsWith('PUB_K1_')) {
-        Key.value = Numeric.publicKeyToLegacyString(
-          Numeric.stringToPublicKey(Key.value)
-        );
-      } else {
-        Key.value = Numeric.convertLegacyPublicKey(Key.value);
-      }
+      legacyKeyFormat.value = !legacyKeyFormat.value;
     }
     return {
-      Key,
+      key,
       Accounts,
+      keyDisplay,
       copy,
       toggleKey,
       tokenLogo
@@ -81,13 +82,13 @@ export default defineComponent({
 						.q-pl-sm
 							q-btn.rotate-315( @click="toggleKey()" flat round color="black" icon="vpn_key" size='xs') &nbsp;
 						.col.wrap
-							.text-weight-normal.key-field {{ Key }}
-								q-btn( @click="copy(Key)" flat round color="black" icon="content_copy" size='xs')
+							.text-weight-normal.key-field {{ keyDisplay }}
+								q-btn( @click="copy(keyDisplay)" flat round color="black" icon="content_copy" size='xs')
 					.row.q-col-gutter-sm
 						.col-12(v-for='account in Accounts')
 							q-card(flat bordered)
 								q-card-section
-									a.hover-dec(:href='"/account/" + account') {{ account }}
+									a.hover-dec(:href='"/account/" + account.toString()') {{ account }}
 
 </template>
 

--- a/src/components/Resources/BuyRam.vue
+++ b/src/components/Resources/BuyRam.vue
@@ -58,8 +58,6 @@ export default defineComponent({
       return store.state?.account.data;
     });
 
-    // const reciever = ref<string>(accountData.abiName);
-
     function formatDec() {
       const precision = store.state.chain.token.precision;
       if (buyOption.value === buyOptions[0]) {

--- a/src/pages/Key.vue
+++ b/src/pages/Key.vue
@@ -3,25 +3,20 @@ import { defineComponent, ref, onMounted } from 'vue';
 import KeyAccountsCard from 'src/components/KeyAccountsCard.vue';
 import { useRoute } from 'vue-router';
 import { api } from 'src/api';
-import { Numeric } from 'eosjs';
+import { Name, PublicKey } from '@greymass/eosio';
 
 /* eslint-disable */
 export default defineComponent({
   name: 'Key',
   setup() {
     const route = useRoute();
-    const pubkey = ref(route.params.key as string);
-    const accounts = ref<string[]>(['']);
+    const pubKey = ref<PublicKey>(PublicKey.from(route.params.key as string));
+    const accounts = ref<Name[]>([]);
     onMounted(async () => {
-      if (pubkey.value.startsWith('PUB_K1_')){
-        pubkey.value = Numeric.publicKeyToLegacyString(
-          Numeric.stringToPublicKey(pubkey.value)
-        );
-      }
-      accounts.value = (await api.getKeyAccounts(pubkey.value)).account_names;
+      accounts.value = (await api.getKeyAccounts(pubKey.value)).account_names;
     });
     return {
-      pubkey,
+      pubKey,
       accounts
     };
   },
@@ -32,7 +27,7 @@ export default defineComponent({
 </script>
 
 <template lang="pug">
-KeyAccountsCard(:pubkey='pubkey' :accounts='accounts')
+KeyAccountsCard(:pubKey='pubKey' :accounts='accounts')
 
 </template>
 

--- a/src/types/Api.ts
+++ b/src/types/Api.ts
@@ -8,7 +8,8 @@ import {
   UInt128,
   UInt64,
   UInt32Type,
-  API
+  API,
+  PublicKey
 } from '@greymass/eosio';
 import { Transaction } from './Transaction';
 import {
@@ -70,6 +71,7 @@ export interface GetTableRowsParams {
 
 export type ApiClient = {
   getAccount: (address: string) => Promise<API.v1.AccountObject>;
+  getKeyAccounts: (key: PublicKey) => Promise<{ account_names: Name[] }>;
   getHyperionAccountData: (address: string) => Promise<AccountDetails>;
   getCreator: (address: string) => Promise<any>;
   getTokens: (address: string) => Promise<Token[]>;


### PR DESCRIPTION
# Fixes #issue_number

## See #447

## Test scenarios
 - visit account, select keys tab, click key to navigate to accounts keys page
 - should display, toggle, and copy as usual

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
