### PR TITLE
488 allow staking to single resource

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -332,6 +332,10 @@ export default defineComponent({
       async () => {
         resetBalances();
         await loadAccountData();
+<<<<<<< Updated upstream
+=======
+        await loadBalances();
+>>>>>>> Stashed changes
       }
     );
 

--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -332,10 +332,6 @@ export default defineComponent({
       async () => {
         resetBalances();
         await loadAccountData();
-<<<<<<< Updated upstream
-=======
-        await loadBalances();
->>>>>>> Stashed changes
       }
     );
 

--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -90,7 +90,6 @@ export default defineComponent({
             ? `${parseFloat(this.netTokens).toFixed(4)} ${symbol}`
             : `0.0000 ${symbol}`
       } as StakeResourcesTransactionData;
-      debugger;
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.transactionId = (

--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -6,6 +6,7 @@ import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { isValidAccount } from 'src/utils/stringValidator';
 import { API } from '@greymass/eosio';
+import { StakeResourcesTransactionData } from 'src/types';
 
 const chain = getChain();
 const symbol = chain.getSystemToken().symbol;
@@ -79,15 +80,17 @@ export default defineComponent({
       const data = {
         from: this.$store.state.account.accountName.toLowerCase(),
         receiver: this.stakingAccount.toLowerCase(),
-        stake_cpu_quantity: `${parseFloat(this.cpuTokens).toFixed(
-          4
-        )} ${symbol}`,
-
-        stake_net_quantity: `${parseFloat(this.netTokens).toFixed(
-          4
-        )} ${symbol}`,
-        transfer: false
-      };
+        transfer: false,
+        stake_cpu_quantity:
+          parseFloat(this.cpuTokens) > 0
+            ? `${parseFloat(this.cpuTokens).toFixed(4)} ${symbol}`
+            : `0.0000 ${symbol}`,
+        stake_net_quantity:
+          parseFloat(this.netTokens) > 0
+            ? `${parseFloat(this.netTokens).toFixed(4)} ${symbol}`
+            : `0.0000 ${symbol}`
+      } as StakeResourcesTransactionData;
+      debugger;
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.transactionId = (

--- a/src/types/StakeResourcesTransactionData.ts
+++ b/src/types/StakeResourcesTransactionData.ts
@@ -1,0 +1,7 @@
+export interface StakeResourcesTransactionData {
+  from: string;
+  receiver: string;
+  transfer: boolean;
+  stake_cpu_quantity?: string;
+  stake_net_quantity?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,6 +27,7 @@ export {
 export { PaginationSettings } from './PaginationSettings';
 export { GenericObj } from './GenericObj';
 export { Transaction } from './Transaction';
+export { StakeResourcesTransactionData } from './StakeResourcesTransactionData';
 export { OptionsObj } from './OptionsObj';
 export { TreeNode } from './TreeNode';
 export {


### PR DESCRIPTION
# Fixes #488 

## Test scenarios
- stake to a single resource (cpu or net) while leaving other as 0.

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
