### PR TITLE
522 buy ram for different account

### DIFF
--- a/src/components/Resources/BuyRam.vue
+++ b/src/components/Resources/BuyRam.vue
@@ -58,6 +58,10 @@ export default defineComponent({
       return store.state?.account.data;
     });
 
+    const receivingAccount = computed((): string =>
+      accountData.value.account_name.toString()
+    );
+
     function formatDec() {
       const precision = store.state.chain.token.precision;
       if (buyOption.value === buyOptions[0]) {
@@ -132,6 +136,7 @@ export default defineComponent({
       transactionError,
       ramAvailable,
       accountData,
+      receivingAccount,
       symbol,
       buyOption,
       buyPreview,
@@ -155,7 +160,9 @@ export default defineComponent({
     .row
       .col-12
         .row.justify-between.q-pb-sm RAM Receiver:
-        q-input.full-width(standout="bg-deep-purple-2 text-white" dense dark v-model="accountData.abiName" :lazy-rules='true' :rules="[ val => isValidAccount(val) || 'Invalid account name.' ]" )
+          q-space
+          .text-grey-3 Defaults to connected account
+        q-input.full-width(standout="bg-deep-purple-2 text-white" dense dark v-model="receivingAccount" :lazy-rules='true' :rules="[ val => isValidAccount(val) || 'Invalid account name.' ]" )
     .row
       .row.q-pb-sm.full-width
         .col-12 {{ `Amount of RAM to buy in ` + buyOption}}

--- a/src/components/Resources/BuyRam.vue
+++ b/src/components/Resources/BuyRam.vue
@@ -20,6 +20,7 @@ export default defineComponent({
     const symbol = ref<string>(chain.getSystemToken().symbol);
     const buyOptions = [symbol.value, 'Bytes'];
     const buyOption = ref<string>(buyOptions[0]);
+    const receivingAccount = ref<string>(store.state.account.accountName);
     const transactionId = computed(
       (): string => store.state.account.TransactionId
     );
@@ -58,10 +59,6 @@ export default defineComponent({
       return store.state?.account.data;
     });
 
-    const receivingAccount = computed((): string =>
-      accountData.value.account_name.toString()
-    );
-
     function formatDec() {
       const precision = store.state.chain.token.precision;
       if (buyOption.value === buyOptions[0]) {
@@ -91,7 +88,8 @@ export default defineComponent({
           return;
         }
         await store.dispatch('account/buyRam', {
-          amount: buyAmount.value + ' ' + symbol.value
+          amount: buyAmount.value + ' ' + symbol.value,
+          receivingAccount: receivingAccount.value
         });
       } else {
         if (
@@ -104,7 +102,8 @@ export default defineComponent({
           return;
         }
         await store.dispatch('account/buyRamBytes', {
-          amount: buyAmount.value
+          amount: buyAmount.value,
+          receivingAccount: receivingAccount.value
         });
       }
       openTransaction.value = true;

--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -125,7 +125,7 @@ export default defineComponent({
       .col-12
         .row.justify-between.q-pb-sm CPU/NET Receiver
           q-space
-          .text-grey-3 Defaults to selected account
+          .text-grey-3 Defaults to connected account
         q-input.full-width(standout="bg-deep-purple-2 text-white" dense  dark v-model="stakingAccount" :lazy-rules='true' :rules="[ val => isValidAccount(val) || 'Invalid account name.' ]" )
     .row.q-py-md
       .col-6

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -465,7 +465,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
       commit('setTransactionError', e);
     }
   },
-  async buyRam({ commit, state }, { amount }) {
+  async buyRam({ commit, state }, { amount, receiver }) {
     let transaction = null;
     const actions = [
       {
@@ -499,7 +499,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
       commit('setTransactionError', e);
     }
   },
-  async buyRamBytes({ commit, state }, { amount }) {
+  async buyRamBytes({ commit, state }, { amount, receiver }) {
     let transaction = null;
     const actions = [
       {

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -465,7 +465,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
       commit('setTransactionError', e);
     }
   },
-  async buyRam({ commit, state }, { amount, receiver }) {
+  async buyRam({ commit, state }, { amount, receivingAccount }) {
     let transaction = null;
     const actions = [
       {
@@ -479,7 +479,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         ],
         data: {
           payer: state.accountName,
-          receiver: state.accountName,
+          receiver: receivingAccount as string,
           quant: amount as string
         }
       }
@@ -499,7 +499,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
       commit('setTransactionError', e);
     }
   },
-  async buyRamBytes({ commit, state }, { amount, receiver }) {
+  async buyRamBytes({ commit, state }, { amount, receivingAccount }) {
     let transaction = null;
     const actions = [
       {
@@ -513,7 +513,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         ],
         data: {
           payer: state.accountName,
-          receiver: state.accountName,
+          receiver: receivingAccount as string,
           bytes: amount as string
         }
       }


### PR DESCRIPTION
# Fixes #522 

## Test scenarios
1. connect account
2. navigate to resources dialog from wallet view
3. click 'buy ram' tab
4. enter a different account for receiver
5. confirm the different account in Anchor as receiver

## Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
