### PR TITLE
Fixes 436: Automatically refresh proposal changes when they're updated

### DIFF
--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
-div(:style="isLoading ? '' : 'max-height: 12rem;'").full-width.row.justify-center.items-center.gradient-box
+div(style="height: fit-content; min-height: 25rem;").full-width.row.justify-center.items-center.gradient-box
   div(v-if="isLoading").col.text-center
     q-spinner(color="white" size="2em")
 
-  div(v-else).col.text-center
+  div(v-else style="height: 22rem; padding-top: 6rem;").col.text-center
     h1.text-h4.text-white.q-ma-none Proposal {{proposalName}}
     p.text-caption.text-white.text-uppercase.q-mt-xs(:style="{opacity:'0.5'}").
       PROPOSER <router-link :to="'/account/' + proposer" class="text-white cursor-pointer">{{proposer}}</router-link> • APPROVAL STATUS {{approvalStatus}} • EXPIRATION {{expirationDate}}
@@ -18,7 +18,7 @@ div(:style="isLoading ? '' : 'max-height: 12rem;'").full-width.row.justify-cente
       q-btn(v-if="isShowApproveButton" outline padding="sm md" color="white" text-color="white" label="Approve" @click="onApprove")
       q-btn(v-if="isShowUnapproveButton" outline padding="sm md" color="white" text-color="white" label="Unapprove" @click="onUnapprove")
 
-q-page(v-if="!isLoading" padding)
+q-page(padding)
   h2.text-h6.text-weight-regular Multisig Transaction
   q-card(
     v-for="(multsigTransactionItem, multsigTransactionIndex) in multsigTransactionData"

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -371,7 +371,9 @@ export default defineComponent({
       return await Promise.all(transactionsPromise);
     }
 
-    onMounted(async () => {
+    onMounted(loadProposalAndUpdateFields);
+    
+    async function loadProposalAndUpdateFields() {
       const proposal = await loadProposal();
 
       if (typeof proposal === 'undefined') {
@@ -410,7 +412,7 @@ export default defineComponent({
       );
 
       isLoading.value = false;
-    });
+    }
 
     async function signTransaction({
       name,
@@ -457,6 +459,8 @@ export default defineComponent({
             }
           }
         });
+        await new Promise((r) => setTimeout(r, 1000));
+        await loadProposalAndUpdateFields();
       } catch (e) {
         console.log(e);
         handleError(e, 'Unable approve proposal');
@@ -476,6 +480,8 @@ export default defineComponent({
             }
           }
         });
+        await new Promise((r) => setTimeout(r, 1000));
+        await loadProposalAndUpdateFields();
       } catch (e) {
         console.log(e);
         handleError(e, 'Unable approve proposal');
@@ -492,6 +498,8 @@ export default defineComponent({
             executer: account.value
           }
         });
+        await new Promise((r) => setTimeout(r, 1000));
+        await loadProposalAndUpdateFields();
       } catch (e) {
         handleError(e, 'Unable execute proposal');
       }
@@ -507,6 +515,8 @@ export default defineComponent({
             canceler: account.value
           }
         });
+        await new Promise((r) => setTimeout(r, 1000));
+        await loadProposalAndUpdateFields();
       } catch (e) {
         handleError(e, 'Unable cancel proposal');
       }

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -106,6 +106,7 @@ import sha256 from 'fast-sha256';
 import { ABI, ABIDef, Action, Serializer, Transaction } from '@greymass/eosio';
 import { useStore } from 'src/store';
 import { deserializeActionDataFromAbi } from 'src/api/eosio_core';
+import { sleep } from 'src/utils/sleep';
 
 export default defineComponent({
   name: 'ProposalItem',
@@ -372,8 +373,10 @@ export default defineComponent({
     }
 
     onMounted(loadProposalAndUpdateFields);
-    
+
     async function loadProposalAndUpdateFields() {
+      isLoading.value = true;
+
       const proposal = await loadProposal();
 
       if (typeof proposal === 'undefined') {
@@ -459,7 +462,7 @@ export default defineComponent({
             }
           }
         });
-        await new Promise((r) => setTimeout(r, 1000));
+        await sleep();
         await loadProposalAndUpdateFields();
       } catch (e) {
         console.log(e);
@@ -480,7 +483,7 @@ export default defineComponent({
             }
           }
         });
-        await new Promise((r) => setTimeout(r, 1000));
+        await sleep();
         await loadProposalAndUpdateFields();
       } catch (e) {
         console.log(e);
@@ -498,7 +501,7 @@ export default defineComponent({
             executer: account.value
           }
         });
-        await new Promise((r) => setTimeout(r, 1000));
+        await sleep();
         await loadProposalAndUpdateFields();
       } catch (e) {
         handleError(e, 'Unable execute proposal');
@@ -515,7 +518,7 @@ export default defineComponent({
             canceler: account.value
           }
         });
-        await new Promise((r) => setTimeout(r, 1000));
+        await sleep();
         await loadProposalAndUpdateFields();
       } catch (e) {
         handleError(e, 'Unable cancel proposal');

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(timeout = 1000): Promise<void> {
+  return new Promise((r) => setTimeout(r, timeout));
+}


### PR DESCRIPTION
# Fixes #436 

## Description

Moved the code from onMounted inside of ProposalItem to a new function that will load the proposal and update the fields, called this new function after signTransition to reload the information. Since we cannot call the new function right after the sign transaction due the chain delay, created a new util function called "sleep" that will wait for one second before reload the UI information. 

## Test scenarios

Manually tested the code on the following scenarios:
- Created a proposal and approve it;
- Unapproved a proposal that was approved;
- Canceled a proposal;
- Executed a proposal;

In all scenarios the UI were successfully refreshed.

## Checklist:
-   [X] I have performed a self-review of my own code
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
