### PR TITLE
Fixes #493: Removing transaction history from ProposalItem

### DIFF
--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -114,7 +114,6 @@ export default defineComponent({
 
     const multsigTransactionData = ref<unknown>({});
     const requestedApprovalsRows = ref<RequestedApprovals[]>([]);
-    const transactionHistoryData = ref<unknown>([]);
 
     const requestedApprovalsColumns = [
       {
@@ -382,7 +381,6 @@ export default defineComponent({
       multsigTransactionData.value = multsigTransactionDataValue;
 
       const transactions = await handleTransactionHistory(proposal.block_num);
-      transactionHistoryData.value = transactions;
 
       isCanceled.value = transactions.some(
         (item) =>
@@ -518,7 +516,6 @@ export default defineComponent({
       multsigTransactionData,
       requestedApprovalsRows,
       requestedApprovalsColumns,
-      transactionHistoryData,
 
       onApprove,
       onUnapprove,

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -72,26 +72,6 @@ q-page(v-if="!isLoading" padding)
               :color="props.row.status ? 'green' : 'orange'"
               :label="props.row.status ? 'APPROVED' : 'PENDING'"
             )
-
-  h2.text-h6.text-weight-regular.q-mt-xl Transaction history
-  q-card(
-    v-for="(transactionHistoryItem, transactionHistoryIndex) in transactionHistoryData"
-    :key="transactionHistoryIndex"
-  ).q-mt-md
-    div(v-for="transactionItem in transactionHistoryItem" :key="transactionItem.trx_id")
-      q-card-section.overflow-auto
-        router-link(
-          :to="'/transaction/' + transactionItem.trx_id"
-          style="text-decoration:none"
-        ).text-primary.cursor-pointer {{transactionItem.trx_id}}
-      json-viewer(
-        :value="transactionHistoryItem[0].act"
-        :expand-depth="5"
-        preview-mode
-        boxed
-        copyable
-        sort
-      )
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
# Fixes #493

## Description

Removing Transaction History from Proposal page since it's not accurate in the most of the times.

Currently we are displaying the transactions that we receive from get_block call, this call can include some transactions that aren't related to the proposal that is being consulted.

Not removing the get_block call since the returned information it's being used in more places.

## Test scenarios

- Opened a Proposal and checked if the Transaction History is being displayed.

## Checklist:
-   [X] I have performed a self-review of my own code
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
