### PR TITLE
#526 | Cleos error fix

### DIFF
--- a/src/components/Resources/BuyRam.vue
+++ b/src/components/Resources/BuyRam.vue
@@ -106,7 +106,10 @@ export default defineComponent({
           receivingAccount: receivingAccount.value
         });
       }
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function buyLimit(): number {

--- a/src/components/Resources/RefundTab.vue
+++ b/src/components/Resources/RefundTab.vue
@@ -126,7 +126,10 @@ export default defineComponent({
         this.transactionError = e;
       }
       await this.loadAccountData();
-      this.openTransaction = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        this.openTransaction = true;
+      }
     },
     async loadAccountData(): Promise<void> {
       try {

--- a/src/components/Resources/SellRam.vue
+++ b/src/components/Resources/SellRam.vue
@@ -57,7 +57,10 @@ export default defineComponent({
       await store.dispatch('account/sellRam', {
         amount: sellAmount.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function assetToAmount(asset: string, decimals = -1): number {

--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -105,7 +105,10 @@ export default defineComponent({
         this.$store.commit('account/setTransactionError', e);
       }
       await this.loadAccountData();
-      this.openTransaction = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        this.openTransaction = true;
+      }
     },
     async loadAccountData(): Promise<void> {
       let data: API.v1.AccountObject;

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -106,7 +106,10 @@ export default defineComponent({
         this.$store.commit('account/setTransactionError', e);
       }
       await this.loadAccountData();
-      this.openTransaction = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        this.openTransaction = true;
+      }
     },
     async loadAccountData(): Promise<void> {
       let data: API.v1.AccountObject;


### PR DESCRIPTION
# Fixes #526 

## Description
This PR fixes an issue where an empty error pops up when copying cleos commands in the account view. The error was due to the application attempting to submit a transaction when, for cleos users, the user is expected to run the command outside of OBE. The fix is to add a simple check before opening a transaction.

## Test scenarios
- go to https://deploy-preview-559--obe-staging.netlify.app/
- login using a cleos account such as `montevideouy` with permission `active`
- go to the account page, eg. `https://deploy-preview-559--obe-staging.netlify.app/account/montevideouy`
- click **resources** button
- do the following steps for each of the tabs "Add CPU/NET", "Remove CPU/NET", "Refund CPU/NET", "Buy RAM", "Sell RAM"
- fill out all fields with any data, e.g. `1 TLOS`
- click `Confirm`
- in the modal that appears, click the `Copy` button
    - the modal should disappear
    - a notification saying "copied to clipboard" should show
    - there should be no error message (this is where the error message shows in prod)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
