### PR TITLE
#526 | Fix cleos errors on staking views

### DIFF
--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -62,7 +62,10 @@ export default defineComponent({
       await store.dispatch('account/moveToSavings', {
         amount: toSavingAmount.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     async function moveFromSavings() {
@@ -77,7 +80,10 @@ export default defineComponent({
       await store.dispatch('account/moveFromSavings', {
         amount: fromSavingAmount.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function assetToAmount(asset: string, decimals = -1): number {

--- a/src/components/Staking/StakeFromResources.vue
+++ b/src/components/Staking/StakeFromResources.vue
@@ -69,7 +69,10 @@ export default defineComponent({
         cpuAmount: cpuTokens.value,
         netAmount: netTokens.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     async function unstake() {
@@ -81,7 +84,10 @@ export default defineComponent({
         cpuAmount: cpuWithdraw.value,
         netAmount: netWithdraw.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function setMaxNetValue() {

--- a/src/components/Staking/StakingTab.vue
+++ b/src/components/Staking/StakingTab.vue
@@ -64,7 +64,10 @@ export default defineComponent({
       await store.dispatch('account/stakeRex', {
         amount: stakeTokens.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function assetToAmount(asset: string, decimals = -1): number {

--- a/src/components/Staking/UnstakingTab.vue
+++ b/src/components/Staking/UnstakingTab.vue
@@ -62,7 +62,10 @@ export default defineComponent({
       await store.dispatch('account/unstakeRex', {
         amount: unstakeTokens.value
       });
-      openTransaction.value = true;
+
+      if (localStorage.getItem('autoLogin') !== 'cleos') {
+        openTransaction.value = true;
+      }
     }
 
     function assetToAmount(asset: string, decimals = -1): number {


### PR DESCRIPTION
# Fixes #526 

## Description
This PR is a followup to #559 where I missed some examples of this error. It fixes an issue where an empty error pops up when copying cleos commands in the account view. The error was due to the application attempting to submit a transaction when, for cleos users, the user is expected to run the command outside of OBE. The fix is to add a simple check before opening a transaction.

## Test scenarios
- go to https://deploy-preview-562--obe-staging.netlify.app/
- login using a cleos account such as `eztestnet123` with permission `active`
- go to the account page, eg. https://deploy-preview-562--obe-staging.netlify.app/account/eztestnet123
- click **Staking (REX)** button
- do the following steps for each of the tabs "Stake", "Unstake", "Stake from CPU/NET", "Savings"
- fill out all fields with any data, e.g. `1 TLOS`
- click `Confirm`
- in the modal that appears, click the `Copy` button
    - the modal should disappear
    - a notification saying "copied to clipboard" should show
    - there should be no error message (this is where the error message shows in prod)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
