### PR TITLE
#539 | Fix bytes display

### DIFF
--- a/src/components/Resources/BuyRam.vue
+++ b/src/components/Resources/BuyRam.vue
@@ -28,7 +28,7 @@ export default defineComponent({
       if (buyOption.value === buyOptions[0]) {
         return (
           ((Number(buyAmount.value) * 1000) / Number(ramPrice.value)).toFixed(
-            4
+            0
           ) +
           ' ' +
           buyOptions[1]


### PR DESCRIPTION
# Fixes #539 

## Description
Currently bytes are displayed as having precision greater than whole numbers, but bytes should be displayed as integers with no decimals in this case. 

## Test scenarios
- sign into an account, e.g. using cleos `eztestnet123`
- go to the account page for your account, e.g. /account/eztestnet123
- click `Resources` button
- go to `Buy RAM` tab
- enter any amount into the `Amount of RAM to buy in TLOS` field
    - the amount of bytes displayed below the input should be an integer rather than a floating point number

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
