### PR TITLE
#487 | Remove nesting from transaction table

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -1,10 +1,5 @@
 <script lang="ts">
-import {
-  Action,
-  PaginationSettings,
-  TransactionTableRow,
-  TransactionTableActionRow
-} from 'src/types';
+import { Action, PaginationSettings, TransactionTableRow } from 'src/types';
 import {
   computed,
   defineComponent,
@@ -141,60 +136,29 @@ export default defineComponent({
               );
       }
       if (tableData) {
-        const map = new Map();
-        tableData.forEach((item) => {
-          if (!item) {
-            return;
-          }
-          const key = item.trx_id;
-          const collection = map.get(key) as {
-            timestamp: string;
-            name: string;
-            actions: TransactionTableActionRow[];
-          };
-          if (!collection) {
-            map.set(key, {
+        rows.value = tableData.map((item) => ({
+          name: item.trx_id,
+          transaction: { id: item.trx_id, type: 'transaction' },
+          timestamp: item['@timestamp'] || item.timestamp,
+          action: item,
+          data: hasActions.value
+            ? { data: item.data as unknown, name: item.account }
+            : { data: item.act.data as unknown, name: item.act.name },
+          actions: [
+            {
               name: item.trx_id,
               transaction: { id: item.trx_id, type: 'transaction' },
-              timestamp: item['@timestamp'] || item.timestamp,
-              action: item,
-              data: hasActions.value
-                ? { data: item.data as unknown, name: item.account as unknown }
-                : { data: item.act.data as unknown, name: item.act.name },
-              actions: [
-                {
-                  name: item.trx_id,
-                  transaction: { id: item.trx_id, type: 'transaction' },
-                  timestamp: item['@timestamp'],
-                  action: item,
-                  data: hasActions.value
-                    ? {
-                        data: item.data as unknown,
-                        name: item.account as unknown
-                      }
-                    : { data: item.act.data as unknown, name: item.act.name }
-                }
-              ]
-            });
-          } else {
-            collection.actions.push({
-              name: item.trx_id,
-              transaction: { id: item.trx_id, type: 'transaction' },
-              timestamp: item['@timestamp'] || item.timestamp,
+              timestamp: item['@timestamp'],
               action: item,
               data: hasActions.value
                 ? {
-                    data: item.act.data as unknown,
+                    data: item.data as unknown,
                     name: item.account
                   }
                 : { data: item.act.data as unknown, name: item.act.name }
-            });
-          }
-        });
-        rows.value = Array.from(
-          map,
-          ([, value]) => value as TransactionTableRow
-        );
+            }
+          ]
+        }));
       }
       void filterRows();
     };
@@ -365,8 +329,6 @@ div.row.col-12.q-mt-xs.justify-center.text-left
             q-toggle(v-model="showAge" left-label label="Show timestamp as relative")
         template(v-slot:header="props")
           q-tr(:props="props")
-            q-th(auto-width)
-
             q-th(
               v-for="col in props.cols"
               :key="col.name"
@@ -374,8 +336,6 @@ div.row.col-12.q-mt-xs.justify-center.text-left
             ) {{ col.label }}
         template( v-slot:body="props")
           q-tr(:props='props')
-            q-td.items-center(auto-width)
-              q-btn( v-if='props.row.actions.length > 1' flat size="sm" :icon="props.expand ? 'expand_less' : 'expand_more'" @click="props.expand = !props.expand")
             q-td
               AccountFormat(:account="props.row.transaction.id" :type="props.row.transaction.type")
             q-td


### PR DESCRIPTION
# Fixes #487

## Description
This PR removes the expandable / collapsible row for actions in the same transaction in the account view. instead all actions are given their own line to match industry standard 

## Test scenarios

**note:** testing must be completed locally
- change line of 6 `.env` file from `CHAIN_NAME=telos-testnet` to `CHAIN_NAME=telos` (this switches to mainnet)
- run `yarn dev`
- go to http://localhost:8080/account/treasury.tcd
- scroll to bottom of page, change records per page to 200, await loading complete
- note that there are 11 transactions with ID `a54fba13`
- compare to the same view here, where the same 11 transfers are nested: https://explorer.telos.net/account/treasury.tcd

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
