### PR TITLE
550 cleos command with nan telos

### DIFF
--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     async sendTransaction(): Promise<void> {
       this.transactionError = '';
       if (parseFloat(this.cpuTokens) <= 0 && parseFloat(this.netTokens) <= 0) {
-        this.$q.notify('Enter valid value for CPU or NET to unstake');
+        this.$q.notify('Enter valid value for CPU or NET to stake');
         return;
       }
       const data = {

--- a/src/components/Resources/StakeTab.vue
+++ b/src/components/Resources/StakeTab.vue
@@ -23,11 +23,11 @@ export default defineComponent({
     const accountTotal = computed((): string =>
       store.state.account.data.core_liquid_balance.toString()
     );
-    const cpuTokens = ref<string>('');
-    const netTokens = ref<string>('');
+    const cpuTokens = ref<string>('0');
+    const netTokens = ref<string>('0');
 
     function formatDec() {
-      if (cpuTokens.value != '') {
+      if (cpuTokens.value != '0') {
         cpuTokens.value = Number(cpuTokens.value)
           .toLocaleString('en-US', {
             style: 'decimal',
@@ -36,7 +36,7 @@ export default defineComponent({
           })
           .replace(/[^0-9.]/g, '');
       }
-      if (netTokens.value != '') {
+      if (netTokens.value != '0') {
         netTokens.value = Number(netTokens.value)
           .toLocaleString('en-US', {
             style: 'decimal',
@@ -74,7 +74,8 @@ export default defineComponent({
   methods: {
     async sendTransaction(): Promise<void> {
       this.transactionError = '';
-      if (this.cpuTokens === '0.0000' && this.netTokens === '0.0000') {
+      if (parseFloat(this.cpuTokens) <= 0 && parseFloat(this.netTokens) <= 0) {
+        this.$q.notify('Enter valid value for CPU or NET to unstake');
         return;
       }
       const data = {

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -2,6 +2,7 @@
 import { defineComponent, ref, computed } from 'vue';
 import { useStore } from 'src/store';
 import { mapActions } from 'vuex';
+import { useQuasar } from 'quasar';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { isValidAccount } from 'src/utils/stringValidator';
@@ -16,11 +17,12 @@ export default defineComponent({
     ViewTransaction
   },
   setup() {
+    const $q = useQuasar();
     const store = useStore();
     const openTransaction = ref<boolean>(false);
     const stakingAccount = ref<string>(store.state.account.accountName || '');
-    const cpuTokens = ref<string>('');
-    const netTokens = ref<string>('');
+    const cpuTokens = ref<string>('0.0000');
+    const netTokens = ref<string>('0.0000');
     const netStake = computed((): string =>
       store.state.account.data.total_resources.net_weight.toString()
     );
@@ -77,7 +79,8 @@ export default defineComponent({
   methods: {
     async sendTransaction(): Promise<void> {
       this.transactionError = '';
-      if (this.cpuTokens === '0.0000' && this.netTokens === '0.0000') {
+      if (parseFloat(this.cpuTokens) <= 0 && parseFloat(this.netTokens) <= 0) {
+        this.$q.notify('Enter valid value for CPU or NET to unstake');
         return;
       }
       const data = {
@@ -133,11 +136,11 @@ export default defineComponent({
     .row.q-pb-md
       .col-6
         .row.justify-between.q-pb-sm REMOVE CPU
-        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="cpuTokens" :lazy-rules='true' :rules="[ val => val <= cpuStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
+        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0' v-model="cpuTokens"  :rules="[ val => val <= cpuStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
 
       .col-6.q-pl-md
         .row.justify-between.q-pb-sm REMOVE NET
-        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000'  v-model="netTokens" :lazy-rules='true' :rules="[ val => val <= netStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
+        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0'  v-model="netTokens"  :rules="[ val => val <= netStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
     .row
       .col-12.q-pt-md
         q-btn.full-width.button-accent(label="Confirm" flat @click="sendTransaction" )

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -21,8 +21,8 @@ export default defineComponent({
     const store = useStore();
     const openTransaction = ref<boolean>(false);
     const stakingAccount = ref<string>(store.state.account.accountName || '');
-    const cpuTokens = ref<string>('0.0000');
-    const netTokens = ref<string>('0.0000');
+    const cpuTokens = ref<string>('0');
+    const netTokens = ref<string>('0');
     const netStake = computed((): string =>
       store.state.account.data.total_resources.net_weight.toString()
     );
@@ -31,7 +31,7 @@ export default defineComponent({
     );
 
     function formatDec() {
-      if (cpuTokens.value != '') {
+      if (cpuTokens.value != '0') {
         cpuTokens.value = Number(cpuTokens.value)
           .toLocaleString('en-US', {
             style: 'decimal',
@@ -40,7 +40,7 @@ export default defineComponent({
           })
           .replace(/[^0-9.]/g, '');
       }
-      if (netTokens.value != '') {
+      if (netTokens.value != '0') {
         netTokens.value = Number(netTokens.value)
           .toLocaleString('en-US', {
             style: 'decimal',

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -83,14 +83,17 @@ export default defineComponent({
       const data = {
         from: this.stakingAccount.toLowerCase(),
         receiver: this.stakingAccount.toLowerCase(),
-        unstake_cpu_quantity: `${parseFloat(this.cpuTokens).toFixed(
-          4
-        )} ${symbol}`,
-        unstake_net_quantity: `${parseFloat(this.netTokens).toFixed(
-          4
-        )} ${symbol}`,
+        unstake_stake_cpu_quantity:
+          parseFloat(this.cpuTokens) > 0
+            ? `${parseFloat(this.cpuTokens).toFixed(4)} ${symbol}`
+            : `0.0000 ${symbol}`,
+        unstake_stake_net_quantity:
+          parseFloat(this.netTokens) > 0
+            ? `${parseFloat(this.netTokens).toFixed(4)} ${symbol}`
+            : `0.0000 ${symbol}`,
         transfer: false
       };
+
       try {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this.transactionId = (

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -136,11 +136,11 @@ export default defineComponent({
     .row.q-pb-md
       .col-6
         .row.justify-between.q-pb-sm REMOVE CPU
-        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0' v-model="cpuTokens"  :rules="[ val => val <= cpuStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
+        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0' v-model="cpuTokens" :lazy-rules="true"  :rules="[ val => val <= cpuStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
 
       .col-6.q-pl-md
         .row.justify-between.q-pb-sm REMOVE NET
-        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0'  v-model="netTokens"  :rules="[ val => val <= netStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
+        q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0'  v-model="netTokens" :lazy-rules="true" :rules="[ val => val <= netStake && val >= 0  || 'Invalid amount.' ]" type="text" dense dark)
     .row
       .col-12.q-pt-md
         q-btn.full-width.button-accent(label="Confirm" flat @click="sendTransaction" )


### PR DESCRIPTION
# Fixes #550 

## Description
- validates transaction inputs for unstake rex and cpu to allow unstaking single resource 
- disables cleos or Anchor transactions if invalid inputs

## Test scenarios
- if cpu and net both left as zero, it should notify prompt the user for input value 
- input non-zero value for cpu, click 'confirm' while logged in via cleos, should display '0.0000 TLOS' for the empty input in the generated cleos command (instead of 'NaN TLOS'), test for net only input as well.  

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
