### PR TITLE
removing fuel when not supported

### DIFF
--- a/src/api/fuel.ts
+++ b/src/api/fuel.ts
@@ -70,6 +70,7 @@ export class FuelUserWrapper extends User {
     originalconfig?: SignTransactionConfig
   ): Promise<SignTransactionResponse> {
     try {
+      // if fuel is not supported, just let the normal implementation to perform
       if (!fuelrpc) {
         return this.user.signTransaction(originalTransaction, originalconfig);
       }

--- a/src/api/fuel.ts
+++ b/src/api/fuel.ts
@@ -70,6 +70,10 @@ export class FuelUserWrapper extends User {
     originalconfig?: SignTransactionConfig
   ): Promise<SignTransactionResponse> {
     try {
+      if (!fuelrpc) {
+        return this.user.signTransaction(originalTransaction, originalconfig);
+      }
+      
       // Retrieve transaction headers
       const info = await client.v1.chain.get_info();
       const header = info.getTransactionHeader(expireSeconds);

--- a/src/api/fuel.ts
+++ b/src/api/fuel.ts
@@ -70,7 +70,7 @@ export class FuelUserWrapper extends User {
     originalconfig?: SignTransactionConfig
   ): Promise<SignTransactionResponse> {
     try {
-      // if fuel is not supported, just let the normal implementation to perform
+      // if fuel is not supported, just let the normal implementation perform
       if (!fuelrpc) {
         return this.user.signTransaction(originalTransaction, originalconfig);
       }


### PR DESCRIPTION
# Fixes #582

## Description
The fuel service is working as expected in the chains that are supported but is introducing problems in the not supported ones. For that, I push this little snippet patch to solve the problem. All the information was always available but never used to discard unsupported chains.

## Test scenarios
- Login to testnet
- open the browser inspector and enter tab Network
- modify filters, select: Fetch/XHR
- try to sign any transaction (send tokens, stake or unstake)
- You should not see a POST request like this: https://telos.greymass.com/v1/resource_provider/request_transaction
- You should be able to perform the signing as regularly (without fuel)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings