### PR TITLE
578 account input validation when signing in w/cleos

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,10 +33,10 @@ module.exports = {
   //TODO increase thresholds as coverage increases as testing will be enforced
   coverageThreshold: {
     global: {
-      statements: 5,
-      branches: 2,
-      functions: 2.5,
-      lines: 5
+      statements: 13,
+      branches: 4,
+      functions: 4.5,
+      lines: 14
     },
     './src/components/': {
       statements: 0,

--- a/src/boot/ual.ts
+++ b/src/boot/ual.ts
@@ -39,6 +39,7 @@ async function loginHandler() {
         persistent: true
       })
         .onOk((data: string) => {
+          data = data.toLowerCase();
           accountName = data != '' ? data : 'eosio';
         })
         .onCancel(() => {

--- a/src/boot/ual.ts
+++ b/src/boot/ual.ts
@@ -5,6 +5,7 @@ import { Chain } from 'src/types/Chain';
 import { getChain } from 'src/config/ConfigManager';
 import { CleosAuthenticator } from '@telosnetwork/ual-cleos';
 import { Dialog, Notify, copyToClipboard } from 'quasar';
+import { isValidAccount } from 'src/utils/stringValidator';
 
 const chain: Chain = getChain();
 
@@ -33,13 +34,14 @@ async function loginHandler() {
         message: 'Account name',
         prompt: {
           model: '',
-          type: 'text'
+          type: 'text',
+          isValid: (val) => isValidAccount(val)
         },
         cancel: true,
         persistent: true
       })
         .onOk((data: string) => {
-          data = data.toLowerCase();
+          data = data;
           accountName = data != '' ? data : 'eosio';
         })
         .onCancel(() => {

--- a/src/boot/ual.ts
+++ b/src/boot/ual.ts
@@ -36,7 +36,7 @@ async function loginHandler() {
       Dialog.create({
         color: 'primary',
         title: 'Connect to cleos',
-        message: 'Account name (a-z,1-5,.)',
+        message: 'Account name (.,a-z,1-5)',
         prompt: {
           model: '',
           type: 'text',

--- a/src/boot/ual.ts
+++ b/src/boot/ual.ts
@@ -31,7 +31,7 @@ async function loginHandler() {
       Dialog.create({
         color: 'primary',
         title: 'Connect to cleos',
-        message: 'Account name',
+        message: 'Account name (a-z,1-5,.)',
         prompt: {
           model: '',
           type: 'text',

--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -3,7 +3,7 @@ import { defineComponent, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { OptionsObj } from 'src/types';
 import { api } from 'src/api';
-import { isValidHex } from 'src/utils/stringValidator';
+import { isValidTransactionHex } from 'src/utils/stringValidator';
 import { useQuasar } from 'quasar';
 
 export default defineComponent({

--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -153,7 +153,7 @@ export default defineComponent({
       }
 
       // transaction validation
-      if (isValidHex(inputValue.value) && inputValue.value.length == 64) {
+      if (isValidTransactionHex(inputValue.value)) {
         await router.push({
           name: 'transaction',
           params: { transaction: inputValue.value }

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -4,7 +4,6 @@ import { useStore } from 'src/store';
 import { mapActions } from 'vuex';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
-import { isValidAccount } from 'src/utils/stringValidator';
 import { API } from '@greymass/eosio';
 
 const chain = getChain();
@@ -71,7 +70,6 @@ export default defineComponent({
       formatDec,
       netStake: assetToAmount(netStake.value),
       cpuStake: assetToAmount(cpuStake.value),
-      isValidAccount
     };
   },
   methods: {

--- a/src/components/Resources/UnstakeTab.vue
+++ b/src/components/Resources/UnstakeTab.vue
@@ -69,7 +69,7 @@ export default defineComponent({
       transactionError: null,
       formatDec,
       netStake: assetToAmount(netStake.value),
-      cpuStake: assetToAmount(cpuStake.value),
+      cpuStake: assetToAmount(cpuStake.value)
     };
   },
   methods: {

--- a/src/components/Staking/StakingDialog.vue
+++ b/src/components/Staking/StakingDialog.vue
@@ -2,7 +2,6 @@
 import { computed, defineComponent, PropType, ref } from 'vue';
 import { Token } from 'src/types';
 import { mapActions, mapGetters } from 'vuex';
-import { isValidAccount } from 'src/utils/stringValidator';
 import StakingInfo from './StakingInfo.vue';
 import StakeFromResources from './StakeFromResources.vue';
 import ProcessingTab from './ProcessingTab.vue';
@@ -79,7 +78,6 @@ export default defineComponent({
     }
   },
   methods: {
-    isValidAccount,
     async sendTransaction(): Promise<void> {
       const actionAccount = this.sendToken.contract;
       const data = {

--- a/src/utils/stringValidator.ts
+++ b/src/utils/stringValidator.ts
@@ -2,7 +2,7 @@
 
 export function isValidAccount(account: string): boolean {
   const regEx = /(^[a-z1-5.]{1,11}[a-z1-5]$)|(^[a-z1-5.]{12}[a-j1-5]$)/;
-  return regEx.exec(account.toLocaleLowerCase()) != null;
+  return regEx.exec(account) != null;
 }
 
 export function isValidHex(hexString: string): boolean {

--- a/src/utils/stringValidator.ts
+++ b/src/utils/stringValidator.ts
@@ -1,7 +1,7 @@
 /* regex to validate EOSIO account name convention see: https://regex101.com/r/d8uKrG/1 */
 
 export function isValidAccount(account: string): boolean {
-  const regEx = /(^[a-z1-5.]{1,11}[a-z1-5]$)|(^[a-z1-5.]{12}[a-j1-5]$)/;
+  const regEx = /(^[a-z1-5.]{1,11}[a-z1-5]$)|(^[a-z1-5.]{12}[a-z1-5]$)/;
   return regEx.exec(account) != null;
 }
 

--- a/src/utils/stringValidator.ts
+++ b/src/utils/stringValidator.ts
@@ -6,6 +6,6 @@ export function isValidAccount(account: string): boolean {
 }
 
 export function isValidTransactionHex(hexString: string): boolean {
-  const regEx = /[0-9A-Fa-f]{64}/g;
+  const regEx = /^([0-9A-Fa-f]){64}$/g;
   return regEx.exec(hexString) != null;
 }

--- a/src/utils/stringValidator.ts
+++ b/src/utils/stringValidator.ts
@@ -5,7 +5,7 @@ export function isValidAccount(account: string): boolean {
   return regEx.exec(account) != null;
 }
 
-export function isValidHex(hexString: string): boolean {
-  const regEx = /[0-9A-Fa-f]{6}/g;
+export function isValidTransactionHex(hexString: string): boolean {
+  const regEx = /[0-9A-Fa-f]{64}/g;
   return regEx.exec(hexString) != null;
 }

--- a/test/jest/__tests__/utils/stringValidator.spec.ts
+++ b/test/jest/__tests__/utils/stringValidator.spec.ts
@@ -1,0 +1,30 @@
+import {
+  describe,
+  expect,
+  it //,
+  // jest,
+  // afterEach,
+  // beforeEach
+} from '@jest/globals';
+import { isValidAccount } from 'src/utils/stringValidator';
+
+describe('stringValidator utility functions', () => {
+  describe('isValidAccount', () => {
+    it('returns true for accounts with lowercase letters, numbers 1-5, containing non-terminating periods up to 13 characters', () => {
+      const validAntelopeAccount = '.abcdef.12345';
+      expect(isValidAccount(validAntelopeAccount)).toBe(true);
+    });
+    it('returns false for account names containing digits > 5', () => {
+      const invalidAntelopeAccount = '123456';
+      expect(isValidAccount(invalidAntelopeAccount)).toBe(false);
+    });
+    it('returns false for account names ending with a period', () => {
+      const invalidAntelopeAccount = 'abc.';
+      expect(isValidAccount(invalidAntelopeAccount)).toBe(false);
+    });
+    it('returns false for accounts names exceeding 13 characters', () => {
+      const invalidAntelopeAccount = 'abcdefghijklmn';
+      expect(isValidAccount(invalidAntelopeAccount)).toBe(false);
+    });
+  });
+});

--- a/test/jest/__tests__/utils/stringValidator.spec.ts
+++ b/test/jest/__tests__/utils/stringValidator.spec.ts
@@ -1,12 +1,8 @@
+import { describe, expect, it } from '@jest/globals';
 import {
-  describe,
-  expect,
-  it //,
-  // jest,
-  // afterEach,
-  // beforeEach
-} from '@jest/globals';
-import { isValidAccount } from 'src/utils/stringValidator';
+  isValidAccount,
+  isValidTransactionHex
+} from 'src/utils/stringValidator';
 
 describe('stringValidator utility functions', () => {
   describe('isValidAccount', () => {
@@ -25,6 +21,26 @@ describe('stringValidator utility functions', () => {
     it('returns false for accounts names exceeding 13 characters', () => {
       const invalidAntelopeAccount = 'abcdefghijklmn';
       expect(isValidAccount(invalidAntelopeAccount)).toBe(false);
+    });
+  });
+
+  describe('isValidTransactionHex', () => {
+    it('returns true if value is 64 characters in length containing valid hex (0-9, A-F, a-f)', () => {
+      const validTransactionHex =
+        '0000000000000000000000000000000000000000000123456789abcdefABCDEF';
+      expect(isValidTransactionHex(validTransactionHex)).toBe(true);
+    });
+    it('returns false if hex does not contain 64 characters', () => {
+      const invalidTransactionHex = 'FFFFFF';
+      expect(isValidTransactionHex(invalidTransactionHex)).toBe(false);
+    });
+    it('returns false if string does not contain valid uppercase characters', () => {
+      const invalidTransactionHex = 'ABCDEFG';
+      expect(isValidTransactionHex(invalidTransactionHex)).toBe(false);
+    });
+    it('returns false if string does not contain valid lowercase characters', () => {
+      const invalidTransactionHex = 'abcdefg';
+      expect(isValidTransactionHex(invalidTransactionHex)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
# Fixes #578 

## Description
- resolves bug where user can input invalid account name when signing in with cleos
- updates regexp for account and transaction hex validation

## Test scenarios
cleos login:
1. click 'connect' and select cleos
2. see updated description in input label
3. attempt to put in invalid character, see 'ok' disabled
4. correct invalid chars, see 'ok' enabled, and continue with login

transaction hex validation:
- in search bar, verify transaction search still works as expected

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
