### PR TITLE
421 staking to savings moves funds from maturing but shows matured as available amount

### DIFF
--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -137,7 +137,7 @@ export default defineComponent({
               .row.items-center.justify-end.q-hoverable.cursor-pointer(@click='setMaxSavingsValue')
                 .text-weight-bold.text-right.balance-amount {{ eligibleStaked }}
                 q-icon.q-ml-xs( name="info" )
-                q-tooltip If there is currently any amount maturing, those funds will be staked to savings first. Click to stake full amount.
+                q-tooltip Any balance currently maturing will be moved first, click to stake full amount
           q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="toSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= eligibleStaked  || 'Invalid amount.' ]" type="text" dense dark)
         .row
           q-btn.full-width.button-accent(label="Move To Savings" flat @click="moveToSavings" )

--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -138,7 +138,7 @@ export default defineComponent({
                 .text-weight-bold.text-right.balance-amount {{ eligibleStaked }}
                 q-icon.q-ml-xs( name="info" )
                 q-tooltip If there is currently any amount maturing, those funds will be staked to savings first. Click to stake full amount.
-          q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="toSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= assetToAmount(maturedRex)  || 'Invalid amount.' ]" type="text" dense dark)
+          q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="toSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= eligibleStaked  || 'Invalid amount.' ]" type="text" dense dark)
         .row
           q-btn.full-width.button-accent(label="Move To Savings" flat @click="moveToSavings" )
       .col-12.q-pt-xl

--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -22,8 +22,11 @@ export default defineComponent({
     const accountData = computed((): API.v1.AccountObject => {
       return store.state?.account.data;
     });
-    const maturedRex = computed(() => {
-      return store.state?.account.maturedRex;
+    const eligibleStaked = computed(() => {
+      return (
+        assetToAmount(store.state?.account.maturedRex) +
+        assetToAmount(store.state?.account.maturingRex)
+      );
     });
     const rexSavings = computed(() => {
       return store.state?.account.savingsRex;
@@ -55,7 +58,7 @@ export default defineComponent({
       if (
         toSavingAmount.value === '0.0000' ||
         toSavingAmount.value === '' ||
-        Number(toSavingAmount.value) >= assetToAmount(maturedRex.value)
+        Number(toSavingAmount.value) >= eligibleStaked.value
       ) {
         return;
       }
@@ -92,7 +95,7 @@ export default defineComponent({
     }
 
     function setMaxSavingsValue() {
-      toSavingAmount.value = assetToAmount(maturedRex.value).toString();
+      toSavingAmount.value = eligibleStaked.value.toString();
       void formatDec();
     }
 
@@ -107,7 +110,7 @@ export default defineComponent({
       accountData,
       toSavingAmount,
       fromSavingAmount,
-      maturedRex,
+      eligibleStaked,
       rexSavings,
       transactionId,
       transactionError,
@@ -132,7 +135,7 @@ export default defineComponent({
             .col-9 STAKE TO SAVINGS
             .col-3
               .row.items-center.justify-end.q-hoverable.cursor-pointer(@click='setMaxSavingsValue')
-                .text-weight-bold.text-right.balance-amount {{maturedRex}}
+                .text-weight-bold.text-right.balance-amount {{ eligibleStaked }}
                 q-icon.q-ml-xs( name="info" )
                 q-tooltip Click to fill full amount
           q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="toSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= assetToAmount(maturedRex)  || 'Invalid amount.' ]" type="text" dense dark)

--- a/src/components/Staking/SavingsTab.vue
+++ b/src/components/Staking/SavingsTab.vue
@@ -137,7 +137,7 @@ export default defineComponent({
               .row.items-center.justify-end.q-hoverable.cursor-pointer(@click='setMaxSavingsValue')
                 .text-weight-bold.text-right.balance-amount {{ eligibleStaked }}
                 q-icon.q-ml-xs( name="info" )
-                q-tooltip Click to fill full amount
+                q-tooltip If there is currently any amount maturing, those funds will be staked to savings first. Click to stake full amount.
           q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="toSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= assetToAmount(maturedRex)  || 'Invalid amount.' ]" type="text" dense dark)
         .row
           q-btn.full-width.button-accent(label="Move To Savings" flat @click="moveToSavings" )
@@ -149,7 +149,7 @@ export default defineComponent({
               .row.items-center.justify-end.q-hoverable.cursor-pointer(@click='setMaxWithdrawValue')
                 .text-weight-bold.text-right.balance-amount {{rexSavings}}
                 q-icon.q-ml-xs( name="info" )
-                q-tooltip Click to fill full amount
+                q-tooltip Click to stake full amount
           q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="fromSavingAmount" :lazy-rules='true' :rules="[ val => val >= 0 && val <= assetToAmount(rexSavings)  || 'Invalid amount.' ]" type="text" dense dark)
         .row
           q-btn.full-width.button-accent(label="Withdraw from Savings" flat @click="moveFromSavings" )


### PR DESCRIPTION
# Fixes #421 

## Test scenarios
1. login and navigate to staking(rex) dialog -> savings tab
2. if not maturing amount, go to stake tab and stake to have a 'maturing' balance
3. full value in the top right of the 'move to savings' input should be the sum of matured and _maturing_
4. input validation for exceed amount should allow inputs up to this sum value
5. tooltip should include a note about maturing funds being moved first.

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
