### PR TITLE
Adapting cleos login dialog to be more responsive

### DIFF
--- a/src/components/WalletModal.vue
+++ b/src/components/WalletModal.vue
@@ -3,15 +3,24 @@ import { computed, defineComponent, ref } from 'vue';
 import { DialogChainObject } from 'quasar';
 import { authenticators } from 'src/boot/ual';
 import { useStore } from 'src/store';
+import { useQuasar } from 'quasar';
+
 
 export default defineComponent({
     name: 'WalletModal',
     setup() {
+        const $q = useQuasar();
         const store = useStore();
         const error = ref<string>(null);
         const account = computed(() => store.state.account.accountName);
         const loading = {};
         const walletDialog = ref<DialogChainObject>(null);
+        const iconSize = computed(() => {
+            if ($q.screen.width > 420) {
+                return '3em';
+            }
+            return '1.5em';
+        });
 
         const onLogin = async (idx: number) => {
             const authenticator = authenticators[idx];
@@ -33,6 +42,7 @@ export default defineComponent({
             account,
             walletDialog,
             onLogin,
+            iconSize,
         };
     },
 });
@@ -41,7 +51,7 @@ export default defineComponent({
 q-dialog.modal-container(ref='walletDialog')
 
   .modal-header-container
-    q-icon( name='add_circle_outline' size='2.5rem' color="white")
+    q-icon( name='add_circle_outline' color="white" :size="iconSize")
     h3.modal-header Attach an account
   q-separator
   q-list
@@ -84,6 +94,7 @@ q-dialog.modal-container(ref='walletDialog')
 .modal-container
   background: radial-gradient(50% 67.35% at 50% 67.35%, #8A65D4 0%,  rgb(9, 26, 98, 100))
 .modal-header
+  margin-left: 0.6rem
   color: white
   font-size: 2.25rem
   width: 100%
@@ -91,4 +102,14 @@ q-dialog.modal-container(ref='walletDialog')
   display: flex
   align-items: center
   box-shadow: unset !important
+
+// on resolutions smaller than 420px h3.modal-header will have smamller text
+  // and a smaller .modal-header-container q-icon
+@media screen and (max-width: 420px)
+  h3.modal-header
+    font-size: 1.5rem
+  .modal-header-container
+    padding: 0 1rem
+  .modal-container .q-dialog__inner
+    padding: 0 1rem
 </style>

--- a/src/components/WalletModal.vue
+++ b/src/components/WalletModal.vue
@@ -103,7 +103,7 @@ q-dialog.modal-container(ref='walletDialog')
   align-items: center
   box-shadow: unset !important
 
-// on resolutions smaller than 420px h3.modal-header will have smamller text
+// on resolutions smaller than 420px h3.modal-header will have smaller text
   // and a smaller .modal-header-container q-icon
 @media screen and (max-width: 420px)
   h3.modal-header

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -79,3 +79,6 @@
 
 .flex-grow-1
   flex-grow: 1
+
+.q-dialog-plugin
+  max-width: 100%


### PR DESCRIPTION
# Fixes #579

## Description
The login modal was too big for a small resolution. This PR adapts the style of the involved components to make it more responsive.

## Test scenarios
- Open the site on a mobile device or use the Desktop browser, open the inspector, and toggle to "device toolbar", so you can see the site in small resolution
- The "Attach an account" title should display smaller so the icon
- Select Cleos for login
- The dialog should be displayed in a nice way using no more than the device with 

## Screenshots
<table>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/4420760/220381908-aa84c118-0663-4093-b4ac-b5055d0afec4.png"></td>
    <td><img src="https://user-images.githubusercontent.com/4420760/220381930-819e7e2f-fe04-4263-826e-9176d63b8c3a.png"></td>
  </tr>
</table>





## Checklist:
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages