### PR TITLE
fix: see-more button now does not break the layout when viewing action traces.

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -1,6 +1,3 @@
-<!-- eslint-disable vue/return-in-computed-property -->
-<!-- eslint-disable @typescript-eslint/no-unused-vars -->
-<!-- eslint-disable prettier/prettier -->
 <script lang="ts">
 import {
     Action,
@@ -626,7 +623,7 @@ div.row.col-12.q-mt-xs.justify-center.text-left
                   .q-pt-xs
                     ActionFormat(:action="action.action")
             q-td
-              DataFormat(:actionData="props.row.data.data" :actionName="props.row.data.name " v-if='props.row.actions.length == 1')
+              DataFormat(:actionData="props.row.data.data" :actionName="props.row.data.name " v-if='props.row.actions.length == 1' :use-color="false")
 
           q-tr.expanded-row(v-show="props.expand" :props="props" v-for='action in props.row.actions')
             q-td(auto-width)
@@ -638,7 +635,7 @@ div.row.col-12.q-mt-xs.justify-center.text-left
               .row.justify-left.text-weight-light
                 ActionFormat(:action="action.action")
             q-td
-              DataFormat(:actionData="action.data.data" :actionName="action.data.name ")
+              DataFormat(:actionData="action.data.data" :actionName="action.data.name " :use-color="false")
     div.row.col-12.items-center.justify-end.q-mt-md.q-mb-sm
       // records per page selector
       q-space

--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -4,108 +4,114 @@ import { TransferData } from 'src/types';
 import AccountFormat from 'src/components/transaction/AccountFormat.vue';
 /* eslint-disable */
 export default defineComponent({
-  name: 'DataFormat',
-  components: { AccountFormat },
-  props: {
-    actionName: {
-      type: String,
-      required: true
+    name: 'DataFormat',
+    components: { AccountFormat },
+    props: {
+        actionName: {
+            type: String,
+            required: true,
+        },
+        actionData: {
+            type: Object,
+            required: true,
+        },
+        useColor: {
+            type: Boolean,
+            required: true,
+        },
     },
-    actionData: {
-      type: Object as any,
-      required: true
-    }
-  },
-  setup(props) {
-    const { actionName, actionData } = toRefs(props);
-    const dataBox = ref(null);
-    const showOverflow = ref(false);
-    const maxHeight = ref(57);
-    const switchHeight = ref(20);
-    const isOverflowing = ref(false);
-    const transferData = computed(() => actionData.value as TransferData);
-    const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
+    setup(props) {
+        const { actionName, actionData, useColor } = toRefs(props);
+        const dataBox = ref(null);
+        const showOverflow = ref(false);
+        const maxHeight = ref(57);
+        const switchHeight = ref(20);
+        const isOverflowing = ref(false);
+        const transferData = computed(() => actionData.value as TransferData);
+        const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
 
-    function formatGeneralData(data: any): any[] {
-      var dict: any[] = [];
-      for (let key in data) {
-        if (data[key] instanceof Object) {
-          if (Array.isArray(data[key])) {
-            var keyValArray: any[] = [];
-            for (let i = 0; i < data[key].length; i++) {
-              if (data[key][i] instanceof Object) {
-                keyValArray = keyValArray.concat(
-                  formatGeneralData(data[key][i])
-                );
-              }
+        function formatGeneralData(data: any): any[] {
+            var dict: any[] = [];
+            for (let key in data) {
+                if (data[key] instanceof Object) {
+                    if (Array.isArray(data[key])) {
+                        var keyValArray: any[] = [];
+                        for (let i = 0; i < data[key].length; i++) {
+                            if (data[key][i] instanceof Object) {
+                                keyValArray = keyValArray.concat(
+                                    formatGeneralData(data[key][i]),
+                                );
+                            }
+                        }
+                        if (keyValArray.length == 0) {
+                            dict.push({ key, value: JSON.stringify(data[key]) });
+                        } else {
+                            dict = dict.concat(keyValArray);
+                        }
+                    } else {
+                        var keyValArray: any[] = [];
+                        let formatData = formatGeneralData(data[key]);
+                        if (formatData.length > 0) {
+                            keyValArray = keyValArray.concat(formatGeneralData(data[key]));
+                            dict = dict.concat(keyValArray);
+                        }
+                    }
+                } else {
+                    dict.push({ key, value: data[key] });
+                }
             }
-            if (keyValArray.length == 0) {
-              dict.push({ key, value: JSON.stringify(data[key]) });
-            } else {
-              dict = dict.concat(keyValArray);
-            }
-          } else {
-            var keyValArray: any[] = [];
-            let formatData = formatGeneralData(data[key]);
-            if (formatData.length > 0) {
-              keyValArray = keyValArray.concat(formatGeneralData(data[key]));
-              dict = dict.concat(keyValArray);
-            }
-          }
-        } else {
-          dict.push({ key, value: data[key] });
+            return dict;
         }
-      }
-      return dict;
-    }
 
-    function updateOverflowing() {
-      isOverflowing.value = (dataBox.value?.clientHeight ?? 0) > maxHeight.value;
-    }
+        function updateOverflowing() {
+            isOverflowing.value = (dataBox.value?.clientHeight ?? 0) > maxHeight.value;
+        }
 
-    watch([actionData,clientHeight], () => {
-      updateOverflowing();
-    });
+        watch([actionData, clientHeight], () => {
+            updateOverflowing();
+        });
 
-    onUpdated(() => {
-      updateOverflowing();
-    });
+        onUpdated(() => {
+            updateOverflowing();
+        });
 
-    function isAccount(data: string): boolean {
-      const accountRegEx = [
-        'account',
-        'to',
-        'from',
-        'owner',
-        'account_name',
-        'voter'
-      ];
-      return accountRegEx.includes(data);
-    }
+        function isAccount(data: string): boolean {
+            const accountRegEx = [
+                'account',
+                'to',
+                'from',
+                'owner',
+                'account_name',
+                'voter',
+            ];
+            return accountRegEx.includes(data);
+        }
 
-    function toggleOverflow() {
-      showOverflow.value = !showOverflow.value;
-    }
+        function toggleOverflow() {
+            showOverflow.value = !showOverflow.value;
+        }
 
-    return {
-      data: actionData,
-      transferData,
-      name: actionName,
-      formatGeneralData,
-      isAccount,
-      dataBox,
-      isOverflowing,
-      showOverflow,
-      toggleOverflow,
-      maxHeight,
-      switchHeight
-    };
-  }
+        return {
+            data: actionData,
+            transferData,
+            name: actionName,
+            formatGeneralData,
+            isAccount,
+            dataBox,
+            isOverflowing,
+            showOverflow,
+            toggleOverflow,
+            maxHeight,
+            switchHeight,
+            useColor,
+        };
+    },
 });
 </script>
 
 <template lang="pug">
 div(
+  class="relative-position"
   :class="showOverflow ? '' : 'overflow-hidden'"
   :style=" (showOverflow || !isOverflowing) ? '' : `max-height: calc(${maxHeight}px - ${switchHeight}px)`"
 )
@@ -126,22 +132,26 @@ div(
         span.text-weight-regular(v-if="isAccount(val.key)")
           AccountFormat(:account="val.value" type="account") &nbsp;
         span.text-weight-regular(v-else) {{val.value}} &nbsp;
-.row(v-if="isOverflowing")
-  q-btn.full-width(
+  q-btn(
+    v-if="isOverflowing"
     flat size="xs"
     :icon="showOverflow ? 'expand_less' : 'expand_more'"
-    :class="showOverflow ? '' : 'q-btn--floating'"
+    :class="{'q-btn--use-color': useColor, 'full-width': showOverflow, 'q-btn--floating': !showOverflow }"
     @click="toggleOverflow")
 </template>
 
 <style lang="sass" scoped>
-
-.q-btn--floating
-  // gradient background from bottom 100% opaque to top 0% opaque
-  background: rgb(255,255,255)
-  background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,1) 40%, rgba(255,255,255,0.7) 80%, rgba(255,255,255,0.3) 100%)
-  // make the button to float on top of the content
-  position: absolute
-  bottom: 0
+.q-btn
+  &--floating
+    // gradient background from bottom 100% opaque to top 0% opaque
+    background: rgb(255,255,255)
+    background: linear-gradient(0deg, rgba(255,255,255,1) 0%, rgba(255,255,255,0.7) 40%, rgba(255,255,255,0.6) 80%, rgba(255,255,255,0.3) 100%)
+    // make the button to float on top of the content
+    position: absolute
+    bottom: 0
+    right: 0
+    left: 0
+  &--use-color
+    background: linear-gradient(0deg, #f3effbff 0%, #f3effbaa 40%, #f3effb77 80%, #f3effb33 100%)
 
 </style>

--- a/src/components/transaction/TraceTree.vue
+++ b/src/components/transaction/TraceTree.vue
@@ -91,7 +91,7 @@ export default defineComponent({
               .text-weight-light @{{ authorization.permission }}
           .col-xs-12.col-md-3
             .row.justify-left.text-weight-light
-              DataFormat(:actionData="prop.node.data" :actionName="prop.node.name ")
+              DataFormat(:actionData="prop.node.data" :actionName="prop.node.name " :use-color="true")
 
       template(v-slot:header-notification="prop")
         .row.items-center.full-width.bordered.q-col-gutter-sm
@@ -107,7 +107,7 @@ export default defineComponent({
               .text-weight-bold {{ authorization.actor }}
               .text-weight-light @{{ authorization.permission }}
           .col-xs-12.col-md-3
-            DataFormat(:actionData="prop.node.data" :actionName="prop.node.name ")
+            DataFormat(:actionData="prop.node.data" :actionName="prop.node.name " :use-color="true")
 
 
 </template>


### PR DESCRIPTION
# Fixes #598 

## Description
The "See more" button was breaking the layout when viewing the Trace tab. This PR fixes that.

## Test scenarios
- Go to this [block page](https://deploy-preview-617--obe-staging.netlify.app/transaction/cbdfa378ab91c8378516fcbfa595726c7b1bd659d0c130786dfb85b852000383?tab=traces) in trace tab
- You should see the action data with a button on top of the lower half of the cell, covering the data with a transparent gradient color.
- The layout should not break (you should not see a big horizontal scroll)

## Screenshots

![image](https://user-images.githubusercontent.com/4420760/220990294-a3625e80-837e-4911-b8f4-be69bb164bb8.png)


## Checklist:
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
