### PR TITLE
#613 | Transfer labels

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -629,9 +629,9 @@ div.row.col-12.q-mt-xs.justify-center.text-left
               .row.justify-left.text-weight-light(v-for='action in props.row.actions')
                 .col-auto
                   .q-pt-xs
-                    ActionFormat(:action="action.action" :showTransferLabel="showTransferLabel")
+                    ActionFormat(:action="action.action" :showTransferLabel="showTransferLabel" :account="account")
             q-td
-              DataFormat(:actionData="props.row.data.data" :actionName="props.row.data.name " v-if='props.row.actions.length == 1')
+              DataFormat(:actionData="props.row.data.data" :actionName="props.row.data.name " v-if='props.row.actions.length === 1')
 
           q-tr.expanded-row(v-show="props.expand" :props="props" v-for='action in props.row.actions')
             q-td(auto-width)

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -56,6 +56,11 @@ export default defineComponent({
             required: false,
             default: null,
         },
+        showTransferLabel: {
+            // show/hide send/receive label for transfers
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props) {
         const route = useRoute();
@@ -624,7 +629,7 @@ div.row.col-12.q-mt-xs.justify-center.text-left
               .row.justify-left.text-weight-light(v-for='action in props.row.actions')
                 .col-auto
                   .q-pt-xs
-                    ActionFormat(:action="action.action")
+                    ActionFormat(:action="action.action" :showTransferLabel="showTransferLabel")
             q-td
               DataFormat(:actionData="props.row.data.data" :actionName="props.row.data.name " v-if='props.row.actions.length == 1')
 

--- a/src/components/transaction/ActionFormat.vue
+++ b/src/components/transaction/ActionFormat.vue
@@ -19,6 +19,11 @@ export default defineComponent({
             type: Object as PropType<Action>,
             required: true,
         },
+        showTransferLabel: {
+            // show/hide send/receive label for transfers
+            type: Boolean,
+            default: false,
+        },
     },
     setup(props) {
         const store = useStore();
@@ -26,18 +31,14 @@ export default defineComponent({
         const divClass = ref<string>('');
         const divContent = ref<string>('');
         const tx = toRef(props, 'action');
+        const showLabel = toRef(props, 'showTransferLabel');
 
         onMounted(() => {
             const data = tx.value.act.data as TransferData;
-            if (data.from === account.value) {
+            if (showLabel.value && data.from === account.value) {
                 divContent.value = 'SEND';
-                divClass.value = 'action-transfer';
-            } else if (data.to === account.value) {
+            } else if (showLabel.value && data.to === account.value) {
                 divContent.value = 'RECEIVE';
-                divClass.value = 'action-transfer';
-            } else {
-                divContent.value = 'TRANSFER';
-                divClass.value = 'action-transfer';
             }
         });
 
@@ -51,16 +52,22 @@ export default defineComponent({
 </script>
 
 <template lang="pug">
-div(:class="'action '+ divClass" v-if="tx.act.name === 'transfer'") {{divContent}}
-div(v-else class="action action-general")
-  AccountFormat(:account="tx.act.account" type="account")
-  span.inline &nbsp; → &nbsp;
-  span.text-no-wrap {{tx.act.name}}
+.action-container
+    div(class="action action-general")
+      AccountFormat(:account="tx.act.account" type="account")
+      span.inline &nbsp; → &nbsp;
+      span.text-no-wrap {{tx.act.name}}
+    div.action.action-transfer(v-if="divContent") {{ divContent }}
 </template>
 
 <style lang="sass" scoped>
+.action-container
+    display: flex
+    justify-content: flex-start
+    align-items: center
+    gap: 8px
+
 .action
-  // margin: 0.5rem 0
   padding: 0 0.5rem
   &.action-transfer
     background: rgba(196, 196, 196, 0.3)

--- a/src/components/transaction/ActionFormat.vue
+++ b/src/components/transaction/ActionFormat.vue
@@ -1,13 +1,11 @@
 <script lang="ts">
 import {
     defineComponent,
-    computed,
     ref,
     PropType,
     toRef,
     onMounted,
 } from 'vue';
-import { useStore } from 'src/store';
 import { Action, TransferData } from 'src/types';
 import AccountFormat from 'src/components/transaction/AccountFormat.vue';
 
@@ -24,21 +22,29 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        account: {
+            type: String || null,
+            required: false,
+            default: null,
+        },
     },
     setup(props) {
-        const store = useStore();
-        const account = computed((): string => store.state.account.accountName);
         const divClass = ref<string>('');
         const divContent = ref<string>('');
         const tx = toRef(props, 'action');
         const showLabel = toRef(props, 'showTransferLabel');
+        const account = toRef(props, 'account');
 
         onMounted(() => {
             const data = tx.value.act.data as TransferData;
-            if (showLabel.value && data.from === account.value) {
-                divContent.value = 'SEND';
-            } else if (showLabel.value && data.to === account.value) {
-                divContent.value = 'RECEIVE';
+            const isTransfer = tx.value.act.name === 'transfer';
+
+            if (showLabel.value && account.value && isTransfer) {
+                if (data.from === account.value) {
+                    divContent.value = 'SEND';
+                } else if (data.to === account.value) {
+                    divContent.value = 'RECEIVE';
+                }
             }
         });
 

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -65,7 +65,7 @@ div.row.col-12
       q-tab( name="children" label="Children" )
   q-tab-panels(v-model="tab").col-12
     q-tab-panel(name="transactions")
-      TransactionsTable(:account='account')
+      TransactionsTable(:account='account' :showTransferLabel="true")
     q-tab-panel(name="contract" v-if="abi")
       ContractTabs
     q-tab-panel(name="tokens")


### PR DESCRIPTION
# Fixes #613 

## Description
This PR modifies the behavior of labels in the transfer tables. Previously, the logged-in user would see special 'send' and 'receive' labels next to transfers involving their account. Now, all actions are displayed the same, including transfers; on an account page, if a transfer involves the account whose page you are viewing, the appropriate send/receive label will be shown next to the action.

## Test scenarios
- go to the home page, https://deploy-preview-619--obe-testnet.netlify.app
    - all actions in the transaction table should look the same, including `eosio -> transfer`
- go to an account page, e.g. https://deploy-preview-619--obe-testnet.netlify.app/account/eztestnet123
    - the `eosio -> transfer` actions should show a send/receive label next to them 
- go to an account page with non-`eosio` transfers, e.g. https://deploy-preview-619--obe-testnet.netlify.app/account/boid
    - trasnfer actions should show a send/receive label next to them 

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
