### PR TITLE
#616 | Send token bug

### DIFF
--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -112,7 +112,7 @@ export default defineComponent({
         };
 
         const setMaxValue = () => {
-            sendAmount.value = (sendToken.value.amount - 0.1).toString();
+            sendAmount.value = sendToken.value.amount.toString();
             void formatDec();
         };
 
@@ -178,7 +178,7 @@ q-dialog( @show='setDefaults' :persistent='true' @hide='resetForm' maximized)
                     .color-grey-3.text-weight-bold.balance-amount {{ sendToken?.amount ? `${sendToken.amount } AVAILABLE` : '--' }}
                     q-icon.q-ml-xs( name="info" )
                     q-tooltip Click to fill full amount
-                q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="sendAmount" :debounce='1000' :rules='[val => val > 0 && val < sendToken?.amount || "invalid amount" ]' type="text" dense dark)
+                q-input.full-width(standout="bg-deep-purple-2 text-white" @blur='formatDec' placeholder='0.0000' v-model="sendAmount" :debounce='1000' :rules='[val => val > 0 && val <= sendToken?.amount || "invalid amount" ]' type="text" dense dark)
             .row
               .col-12
                 .row.justify-between.q-px-sm.q-pb-sm.q-gutter-x-sm OPTIONAL MEMO


### PR DESCRIPTION
# Fixes #616

## Description
This PR changes the behavior of the send token input on the account page. When clicking the max amount, the full amount is filled rather than the full amount minus 0.1.

## Test scenarios
- go to https://deploy-preview-621--obe-testnet.netlify.app/
- log into `hyogasereiou` using cleos
- go to https://deploy-preview-621--obe-testnet.netlify.app/account/hyogasereiou
- click `Send`
- click the amount shown above the token amount input
    - the full amount should populate in the field

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
