### PR TITLE
#624 | Fix for undefined account balance

### DIFF
--- a/src/components/resources/BuyRam.vue
+++ b/src/components/resources/BuyRam.vue
@@ -110,11 +110,10 @@ export default defineComponent({
 
         function buyLimit(): number {
             if (buyOption.value === buyOptions[0]) {
-                return accountData.value.core_liquid_balance.value;
+                return accountData.value.core_liquid_balance?.value ?? 0;
             } else {
                 return (
-                    (Number(accountData.value.core_liquid_balance.value) * 1000) /
-          Number(ramPrice.value)
+                    (Number(accountData.value.core_liquid_balance?.value ?? 0) * 1000) / Number(ramPrice.value)
                 );
             }
         }

--- a/src/components/resources/ResourcesInfo.vue
+++ b/src/components/resources/ResourcesInfo.vue
@@ -47,7 +47,7 @@ export default defineComponent({
         const accountTotal = computed(() => {
             let value = 0;
             if (accountData.value) {
-                value = accountData.value?.core_liquid_balance.value;
+                value = accountData.value?.core_liquid_balance?.value ?? 0;
             }
             return value;
         });

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -21,7 +21,7 @@ export default defineComponent({
         const openTransaction = ref<boolean>(false);
         const stakingAccount = ref<string>(store.state.account.accountName || '');
         const accountTotal = computed((): string =>
-            store.state.account.data.core_liquid_balance.toString(),
+            (store.state.account.data.core_liquid_balance ?? 0).toString(),
         );
         const cpuTokens = ref<string>('0');
         const netTokens = ref<string>('0');


### PR DESCRIPTION
# Fixes #624 

## Description
This PR adds in handling for null account balance scenario

## Test scenarios
- this one needs to be tested locally using main net
- edit `.env` file to say `CHAIN_NAME=telos`
- run `yarn dev`
- go to http://localhost:8080
- log in using cleos as `saorinhamala`
- go to http://localhost:8080/account/saorinhamala
- click Resources
- click the Buy RAM tab
    - the tab should load rather than error out

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
