### PR TITLE
#601 | Fix pagination buttons

### DIFF
--- a/src/api/hyperion.ts
+++ b/src/api/hyperion.ts
@@ -29,6 +29,7 @@ import {
 import { Chain } from 'src/types/Chain';
 import { getChain } from 'src/config/ConfigManager';
 import { HyperionTransactionFilter } from 'src/types/Api';
+import { GetActionsResponse } from 'src/types/Actions';
 
 const chain: Chain = getChain();
 const hyperion = axios.create({ baseURL: chain.getHyperionEndpoint() });
@@ -122,7 +123,7 @@ export const getTokens = async function (address?: string): Promise<Token[]> {
 
 export const getTransactions = async function (
     filter: HyperionTransactionFilter,
-): Promise<Action[]> {
+): Promise<GetActionsResponse> {
     const account = filter.account || '';
     const page = filter.page || 1;
     const limit = filter.limit || 10;
@@ -160,10 +161,9 @@ export const getTransactions = async function (
 
     const params: AxiosRequestConfig = aux as AxiosRequestConfig;
 
-    const response = await hyperion.get<ActionData>('v2/history/get_actions', {
+    return await hyperion.get<ActionData>('v2/history/get_actions', {
         params,
     });
-    return response.data.actions;
 };
 
 export const getTransaction = async function (

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -101,6 +101,7 @@ export default defineComponent({
             },
         ];
         const rows = ref<TransactionTableRow[]>([]);
+        const totalRows = ref<number>(0);
         const filteredRows = ref<TransactionTableRow[]>([]);
         const loading = ref<boolean>(false);
         const showPagesSizes = ref<boolean>(false);
@@ -201,7 +202,7 @@ export default defineComponent({
 
         const lastPage = computed(() => {
             const rowsPerPage = paginationSettings.value.rowsPerPage;
-            const rowsNumber = paginationSettings.value.rowsNumber;
+            const rowsNumber = totalRows.value;
             return Math.ceil(rowsNumber / rowsPerPage);
         });
 
@@ -274,7 +275,7 @@ export default defineComponent({
                 if (tokenModel.value) {
                     limit = 100;
                 }
-                tableData = await api.getTransactions({
+                const response = await api.getTransactions({
                     page,
                     limit,
                     account: account.value,
@@ -284,6 +285,8 @@ export default defineComponent({
                     sort,
                     extras,
                 });
+                tableData = response.data.actions;
+                totalRows.value = response.data.total.value;
             }
 
             if (tableData) {
@@ -508,6 +511,7 @@ export default defineComponent({
             loadTableData,
             checkIsMultiLine,
             filterRows,
+            totalRows,
             pageSizeOptions,
             changePageSize,
             switchPageSelector,

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -834,7 +834,7 @@ export default defineComponent({
                         <q-btn
                             class="q-ml-xs q-mr-xs col button-primary"
                             size="sm"
-                            :disable="paginationSettings.page === lastPage"
+                            :disable="paginationSettings.page === lastPage || totalRows < paginationSettings.rowsPerPage"
                             @click="moveTablePage($refs.main_table, 'next')"
                         >NEXT</q-btn>
                     </div>

--- a/src/types/Actions.ts
+++ b/src/types/Actions.ts
@@ -12,6 +12,15 @@ export interface ActionData {
   };
 }
 
+export interface GetActionsResponse {
+    data: {
+        actions: Action[],
+        total: {
+            value: number
+        }
+    },
+}
+
 export interface Action {
   '@timestamp': string;
   account_ram_deltas: AccountRamDelta[];


### PR DESCRIPTION
# Fixes #601 

## Description
This PR updates the logic in TransactionTable to get the full number of rows from the API rather than hardcoded amount. this allows the "next" button to be disabled when there are no more results

## Test scenarios
- go to https://deploy-preview-642--obe-testnet.netlify.app/account/eztestnet123
- go to second page of transactions
    - next button should be disabled

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
