### PR TITLE
#628 | Account inputs updates

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -76,9 +76,8 @@ export default defineComponent({
         const availableTokens = ref<Token[]>([]);
 
         const stakedRefund = computed((): number =>
-            (accountData.value?.refund_request?.cpu_amount.value +
-             accountData.value?.refund_request?.net_amount.value)
-             ?? 0,
+            (accountData.value?.refund_request?.cpu_amount.value ?? 0) +
+            (accountData.value?.refund_request?.net_amount.value ?? 0),
         );
 
         const staked = computed((): number => stakedRefund.value + stakedNET.value + stakedCPU.value);

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -200,7 +200,7 @@ export default defineComponent({
                                     <div>AMOUNT</div>
                                     <q-space/>
                                     <div class="row flex-center q-hoverable cursor-pointer" @click="setMaxValue">
-                                        <div class="color-grey-3 text-weight-bold balance-amount">{{ sendToken?.amount ? `${sendToken.amount } AVAILABLE` : '--' }}</div>
+                                        <div class="color-grey-3 text-weight-bold balance-amount">{{ `${sendToken.amount } AVAILABLE` }}</div>
                                         <q-icon class="q-ml-xs" name="info"/>
                                         <q-tooltip>Click to fill full amount</q-tooltip>
                                     </div>

--- a/src/components/resources/BuyRam.vue
+++ b/src/components/resources/BuyRam.vue
@@ -209,11 +209,8 @@ export default defineComponent({
         <div class="row q-mb-md">
             <div class="row q-pb-sm full-width">
                 <div class="col-6">{{ `Amount of RAM to buy in ` + buyOption}}</div>
-                <div class="col-6">
-                    <div class="color-grey-3 flex justify-end items-center" @click="buyAmount = (buyLimit() - 0.1).toString()"><span class="text-weight-bold balance-amount">{{ `${prettyBuyLimit()} AVAILABLE` }}</span>
-                        <q-icon class="q-ml-xs" name="info"/>
-                        <q-tooltip>Click to fill full amount</q-tooltip>
-                    </div>
+                <div class="col-6 text-right">
+                    <span class="text-weight-bold">{{ `${prettyBuyLimit()} AVAILABLE` }}</span>
                 </div>
             </div>
             <q-input
@@ -259,8 +256,4 @@ export default defineComponent({
   color: $grey-4
 .grey-3
   color: $grey-3
-
-.balance-amount:hover
-  color: $primary
-  cursor: pointer
 </style>

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -61,20 +61,6 @@ export default defineComponent({
             }
         }
 
-        function handleClickMaxCpu() {
-            if (+accountTotalAsNumber.value >= 0.1) {
-                cpuTokens.value = (+accountTotalAsNumber.value - 0.1).toString();
-                netTokens.value = '0';
-            }
-        }
-
-        function handleClickMaxNet() {
-            if (+accountTotalAsNumber.value >= 0.1) {
-                netTokens.value = (+accountTotalAsNumber.value - 0.1).toString();
-                cpuTokens.value = '0';
-            }
-        }
-
         return {
             openTransaction,
             stakingAccount,
@@ -84,8 +70,6 @@ export default defineComponent({
             transactionId: ref<string>(null),
             transactionError: null,
             formatDec,
-            handleClickMaxCpu,
-            handleClickMaxNet,
             accountTotalAsNumber,
             isValidAccount,
         };
@@ -94,7 +78,7 @@ export default defineComponent({
         inputRules(): Array<(data: string) => boolean | string> {
             return [
                 (val: string) => +val >= 0 || 'Value must not be negative',
-                (val: string) => +val < (this.accountTotalAsNumber - 0.1) || 'Not enough funds',
+                (val: string) => +val < this.accountTotalAsNumber || 'Not enough funds',
             ];
         },
         notEnoughTlosForTransaction(): boolean {
@@ -184,12 +168,9 @@ export default defineComponent({
             <div class="col-6">
                 <div class="row q-pb-sm">
                     <div class="col-6">ADD CPU</div>
-                    <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="handleClickMaxCpu">
-                            <span class="text-weight-bold balance-amount">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
-                            <q-icon class="q-ml-xs" name="info"/>
-                            <q-tooltip>Click to fill full amount</q-tooltip>
-                        </div>
+                    <div class="col-6 text-right">
+                        <span class="text-weight-bold">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
+
                     </div>
                 </div>
                 <q-input
@@ -208,12 +189,8 @@ export default defineComponent({
             <div class="col-6 q-pl-md">
                 <div class="row q-pb-sm">
                     <div class="col-6">ADD NET</div>
-                    <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="handleClickMaxNet">
-                            <span class="text-weight-bold balance-amount">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
-                            <q-icon class="q-ml-xs" name="info"/>
-                            <q-tooltip>Click to fill full amount</q-tooltip>
-                        </div>
+                    <div class="col-6 text-right">
+                        <span class="text-weight-bold">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
                     </div>
                 </div>
                 <q-input
@@ -258,8 +235,4 @@ export default defineComponent({
     background: rgba(108, 35, 255, 1)
     border-radius: 4px
     color: $grey-4
-
-.balance-amount:hover
-  color: $primary
-  cursor: pointer
 </style>

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -23,6 +23,7 @@ export default defineComponent({
         const accountTotal = computed((): string =>
             (store.state.account.data.core_liquid_balance ?? 0).toString(),
         );
+        const accountTotalAsNumber = computed(() => assetToAmount(accountTotal.value));
         const cpuTokens = ref<string>('0');
         const netTokens = ref<string>('0');
 
@@ -60,6 +61,20 @@ export default defineComponent({
             }
         }
 
+        function handleClickMaxCpu() {
+            if (+accountTotalAsNumber.value >= 0.1) {
+                cpuTokens.value = (+accountTotalAsNumber.value - 0.1).toString();
+                netTokens.value = '0';
+            }
+        }
+
+        function handleClickMaxNet() {
+            if (+accountTotalAsNumber.value >= 0.1) {
+                netTokens.value = (+accountTotalAsNumber.value - 0.1).toString();
+                cpuTokens.value = '0';
+            }
+        }
+
         return {
             openTransaction,
             stakingAccount,
@@ -69,7 +84,9 @@ export default defineComponent({
             transactionId: ref<string>(null),
             transactionError: null,
             formatDec,
-            accountTotal: assetToAmount(accountTotal.value),
+            handleClickMaxCpu,
+            handleClickMaxNet,
+            accountTotalAsNumber,
             isValidAccount,
         };
     },
@@ -77,11 +94,11 @@ export default defineComponent({
         inputRules(): Array<(data: string) => boolean | string> {
             return [
                 (val: string) => +val >= 0 || 'Value must not be negative',
-                (val: string) => +val < this.accountTotal || 'Not enough funds',
+                (val: string) => +val < (this.accountTotalAsNumber - 0.1) || 'Not enough funds',
             ];
         },
         notEnoughTlosForTransaction(): boolean {
-            return +this.cpuTokens + +this.netTokens > this.accountTotal;
+            return +this.cpuTokens + +this.netTokens > this.accountTotalAsNumber;
         },
         disableCta(): boolean {
             const allZero = +this.cpuTokens === 0 && +this.netTokens === 0;
@@ -168,7 +185,8 @@ export default defineComponent({
                 <div class="row q-pb-sm">
                     <div class="col-6">ADD CPU</div>
                     <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="cpuTokens = (accountTotal - 0.1).toString(); netTokens = '0'"><span class="text-weight-bold balance-amount">{{ accountTotal ? `${accountTotal } AVAILABLE` : '--' }}</span>
+                        <div class="color-grey-3 flex justify-end items-center" @click="handleClickMaxCpu">
+                            <span class="text-weight-bold balance-amount">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
                             <q-icon class="q-ml-xs" name="info"/>
                             <q-tooltip>Click to fill full amount</q-tooltip>
                         </div>
@@ -191,7 +209,8 @@ export default defineComponent({
                 <div class="row q-pb-sm">
                     <div class="col-6">ADD NET</div>
                     <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="netTokens = (accountTotal - 0.1).toString(); cpuTokens = '0'"><span class="text-weight-bold balance-amount">{{ accountTotal ? `${accountTotal } AVAILABLE` : '--' }}</span>
+                        <div class="color-grey-3 flex justify-end items-center" @click="handleClickMaxNet">
+                            <span class="text-weight-bold balance-amount">{{ `${accountTotalAsNumber} AVAILABLE` }}</span>
                             <q-icon class="q-ml-xs" name="info"/>
                             <q-tooltip>Click to fill full amount</q-tooltip>
                         </div>

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -156,7 +156,8 @@ export default defineComponent({
                 <div class="row q-pb-sm">
                     <div class="col-6">REMOVE CPU</div>
                     <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="cpuTokens = cpuStake.toString()"><span class="text-weight-bold balance-amount">{{ cpuStake ? `${cpuStake } AVAILABLE` : '--' }}</span>
+                        <div class="color-grey-3 flex justify-end items-center" @click="cpuTokens = cpuStake.toString()">
+                            <span class="text-weight-bold balance-amount">{{ `${cpuStake} AVAILABLE` }}</span>
                             <q-icon class="q-ml-xs" name="info"/>
                             <q-tooltip>Click to fill full amount</q-tooltip>
                         </div>
@@ -179,7 +180,8 @@ export default defineComponent({
                 <div class="row q-pb-sm">
                     <div class="col-6">REMOVE NET</div>
                     <div class="col-6">
-                        <div class="color-grey-3 flex justify-end items-center" @click="netTokens = netStake.toString()"><span class="text-weight-bold balance-amount">{{ netStake ? `${netStake } AVAILABLE` : '--' }}</span>
+                        <div class="color-grey-3 flex justify-end items-center" @click="netTokens = netStake.toString()">
+                            <span class="text-weight-bold balance-amount">{{ `${netStake} AVAILABLE` }}</span>
                             <q-icon class="q-ml-xs" name="info"/>
                             <q-tooltip>Click to fill full amount</q-tooltip>
                         </div>
@@ -225,4 +227,7 @@ export default defineComponent({
     background: rgba(108, 35, 255, 1)
     border-radius: 4px
     color: $grey-4
+.balance-amount:hover
+    cursor: pointer
+    color: $primary
 </style>

--- a/src/components/staking/StakingTab.vue
+++ b/src/components/staking/StakingTab.vue
@@ -31,6 +31,11 @@ export default defineComponent({
             () => accountData.value?.core_liquid_balance.value,
         );
 
+        const inputRules = computed((): Array<(data: string) => boolean | string> => [
+            (val: string) => +val >= 0 || 'Value must not be negative',
+            (val: string) => +val <= assetToAmount((accountData.value.core_liquid_balance ?? 0).toString()) || 'Balance too low',
+        ]);
+
         function formatDec() {
             const precision = store.state.chain.token.precision;
             if (stakeTokens.value !== '') {
@@ -77,7 +82,7 @@ export default defineComponent({
 
         function setMaxValue() {
             stakeTokens.value = (
-                assetToAmount(accountData.value.core_liquid_balance.toString()) - 0.1
+                assetToAmount(accountData.value.core_liquid_balance.toString())
             ).toString();
             void formatDec();
         }
@@ -93,6 +98,7 @@ export default defineComponent({
             maturedRex,
             liquidBalance,
             symbol,
+            inputRules,
             formatDec,
             stake,
             assetToAmount,
@@ -108,12 +114,12 @@ export default defineComponent({
     <q-card-section>
         <div class="row q-col-gutter-md">
             <div class="col-12">
-                <div class="row">
+                <div class="row q-mb-md">
                     <div class="row q-pb-sm full-width">
                         <div class="col-8">{{ `LIQUID ${symbol}` }}</div>
                         <div class="col-4">
                             <div class="row items-center justify-end q-hoverable cursor-pointer" @click="setMaxValue">
-                                <div class="text-weight-bold text-right balance-amount">{{ `${liquidBalance} ${symbol}` }}</div>
+                                <div class="text-weight-bold text-right balance-amount">{{ `${liquidBalance} AVAILABLE` }}</div>
                                 <q-icon class="q-ml-xs" name="info"/>
                                 <q-tooltip>Click to fill full amount</q-tooltip>
                             </div>
@@ -127,7 +133,7 @@ export default defineComponent({
                         standout="bg-deep-purple-2 text-white"
                         placeholder='0.0000'
                         :lazy-rules='true'
-                        :rules="[ val => val >= 0 && val <= assetToAmount(accountData.core_liquid_balance.toString())  || 'Invalid amount.' ]"
+                        :rules="inputRules"
                         type="text"
                         @blur='formatDec'
                     />


### PR DESCRIPTION
# Fixes #628 

## Description
This PR does the following:
- fixes a null handling issue
- updates error messaging for the Staking input
- removes click-to-fill-maximum value for resources inputs
- removes reserved 0.1 TLOS where applicable for inputs 

## Test scenarios

- go to https://deploy-preview-647--obe-testnet.netlify.app/
- sign in using cleos as `eztestnet111` (zero liquid balance account)
- go to https://deploy-preview-647--obe-testnet.netlify.app/account/eztestnet111
- click Resources
    - "Add CPU/Net" and "Buy RAM" tabs should no longer have the ability to click the total amount to fill the input
- exit Resources dialog
- sign out and sign in as `eztestnet123` (non-zero liquid balance)
- go to https://deploy-preview-647--obe-testnet.netlify.app/account/eztestnet123
- click Staking (REX)
- attempt to put a negative value into the staking input 
    - you should see an appropriate error message
- attempt to put a value larger than the account's liquid balance
    - you should see an appropriate error message


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] I have removed any unnecessary console messages

