### PR TITLE
send token filtering broken

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -577,9 +577,19 @@ export default defineComponent({
             </thead>
         </q-markup-table>
         <div v-if="isAccount">
-            <SendDialog v-model="openSendDialog" :availableTokens="availableTokens" @update-token-balances="updateTokenBalances"/>
-            <ResourcesDialog v-if="openResourcesDialog" v-model="openResourcesDialog"/>
-            <StakingDialog v-model="openStakingDialog" :availableTokens="availableTokens"/>
+            <SendDialog
+                v-model="openSendDialog"
+                :availableTokens="availableTokens"
+                @update-token-balances="updateTokenBalances"
+            />
+            <ResourcesDialog
+                v-if="openResourcesDialog"
+                v-model="openResourcesDialog"
+            />
+            <StakingDialog
+                v-model="openStakingDialog"
+                :availableTokens="availableTokens"
+            />
         </div>
     </q-card>
     <q-card v-else class="account-card">

--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -28,7 +28,7 @@ export default defineComponent({
                 authenticator && (await authenticator.logout());
                 clearAccount();
             } catch (error) {
-                console.log('Authenticator logout error', error);
+                console.error('Authenticator logout error', error);
                 clearAccount();
             }
         };

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -32,8 +32,6 @@ export default defineComponent({
         const sendAmount = ref<string>('');
         const memo = ref<string>('');
 
-        console.log('availableTokens.value', availableTokens.value);
-
         const account = computed(() => store.state.account.accountName);
         const transactionId = computed(
             (): string => store.state.account.TransactionId,
@@ -51,11 +49,11 @@ export default defineComponent({
 
         const sendTransaction = async (): Promise<void> => {
             void store.dispatch('account/resetTransaction');
-            const actionAccount = sendToken.value.contract;
+            const actionAccount = sendToken.value?.contract;
             const data = {
                 from: account.value,
                 to: receivingAccount.value,
-                quantity: `${sendAmount.value} ${sendToken.value.symbol}`,
+                quantity: `${sendAmount.value} ${sendToken.value?.symbol}`,
                 memo: memo.value,
             };
             await store.dispatch('account/sendAction', {
@@ -70,19 +68,17 @@ export default defineComponent({
             void store.dispatch('account/resetTransaction');
             if (availableTokens.value.length > 0) {
                 sendToken.value = availableTokens.value.find(token => (
-                    token.symbol === sendToken.value.symbol &&
-                    token.contract === sendToken.value.contract
+                    token.symbol === sendToken.value?.symbol &&
+                    token.contract === sendToken.value?.contract
                 ));
             }
         };
 
         const updateSelectedCoin = (token: Token): void => {
-            console.log('updateSelectedCoin()', token);
             sendToken.value = token;
         };
 
         const resetForm = () => {
-            console.log('resetForm()');
             sendToken.value = {
                 symbol: chain.getSystemToken().symbol,
                 precision: 4,
@@ -101,7 +97,6 @@ export default defineComponent({
         };
 
         const formatDec = () => {
-            console.log('formatDec()');
             let amount = Number(sendAmount.value);
             if (sendAmount.value !== '') {
                 sendAmount.value = amount
@@ -141,6 +136,25 @@ export default defineComponent({
             formatDec,
             resetForm,
         };
+    },
+    // watch availableTokens and if it changes print the new value
+    watch: {
+        availableTokens: {
+            handler() {
+                if (this.availableTokens.length > 0) {
+                    this.sendToken = this.availableTokens.find(token => (
+                        token.symbol === this.sendToken.symbol &&
+                        token.contract === this.sendToken.contract
+                    ));
+                }
+
+                if (!this.sendToken || this.sendToken.amount === 0) {
+                    this.openCoinDialog = true;
+                }
+            },
+            deep: true,
+            immediate: true,
+        },
     },
 });
 </script>

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -32,6 +32,8 @@ export default defineComponent({
         const sendAmount = ref<string>('');
         const memo = ref<string>('');
 
+        console.log('availableTokens.value', availableTokens.value);
+
         const account = computed(() => store.state.account.accountName);
         const transactionId = computed(
             (): string => store.state.account.TransactionId,
@@ -69,16 +71,18 @@ export default defineComponent({
             if (availableTokens.value.length > 0) {
                 sendToken.value = availableTokens.value.find(token => (
                     token.symbol === sendToken.value.symbol &&
-            token.contract === sendToken.value.contract
+                    token.contract === sendToken.value.contract
                 ));
             }
         };
 
         const updateSelectedCoin = (token: Token): void => {
+            console.log('updateSelectedCoin()', token);
             sendToken.value = token;
         };
 
         const resetForm = () => {
+            console.log('resetForm()');
             sendToken.value = {
                 symbol: chain.getSystemToken().symbol,
                 precision: 4,
@@ -97,6 +101,7 @@ export default defineComponent({
         };
 
         const formatDec = () => {
+            console.log('formatDec()');
             let amount = Number(sendAmount.value);
             if (sendAmount.value !== '') {
                 sendAmount.value = amount
@@ -200,7 +205,7 @@ export default defineComponent({
                                     <div>AMOUNT</div>
                                     <q-space/>
                                     <div class="row flex-center q-hoverable cursor-pointer" @click="setMaxValue">
-                                        <div class="color-grey-3 text-weight-bold balance-amount">{{ `${sendToken?.amount } AVAILABLE` }}</div>
+                                        <div class="color-grey-3 text-weight-bold balance-amount">{{ `${sendToken?.amount ?? 0 } AVAILABLE` }}</div>
                                         <q-icon class="q-ml-xs" name="info"/>
                                         <q-tooltip>Click to fill full amount</q-tooltip>
                                     </div>

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -203,8 +203,8 @@ export default defineComponent({
                     });
 
                     actionSkip += actionLimit;
-                } catch (error) {
-                    console.log(error);
+                } catch (e) {
+                    console.error(e);
                 }
             }
 
@@ -359,7 +359,7 @@ export default defineComponent({
                 await sleep();
                 await loadProposalAndUpdateFields();
             } catch (e) {
-                console.log(e);
+                console.error(e);
                 handleError(e, 'Unable approve proposal');
             }
         }
@@ -380,7 +380,7 @@ export default defineComponent({
                 await sleep();
                 await loadProposalAndUpdateFields();
             } catch (e) {
-                console.log(e);
+                console.error(e);
                 handleError(e, 'Unable approve proposal');
             }
         }

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -180,7 +180,6 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         return this.dispatch('sendTransaction', actions);
     },
     async sendTransaction({ commit, state }, actions: Action[]) {
-        console.log('sendTransaction', actions);
         let transaction = null;
         try {
             transaction = await state.user.signTransaction(

--- a/src/store/chain/actions.ts
+++ b/src/store/chain/actions.ts
@@ -54,7 +54,7 @@ export const actions: ActionTree<ChainStateInterface, StateInterface> = {
             commit('setProducers', producers);
             commit('setBpList', producerData);
         } catch (err) {
-            console.log('Error', err);
+            console.error(err);
         }
     },
     async updateBlockData({ commit }) {
@@ -64,7 +64,7 @@ export const actions: ActionTree<ChainStateInterface, StateInterface> = {
             commit('setLIB', info.last_irreversible_block_num);
             commit('setHead_block_producer', info.head_block_producer);
         } catch (err) {
-            console.log('Error', err);
+            console.error(err);
         }
     },
     async updateRamPrice({ commit }) {
@@ -90,7 +90,7 @@ export const actions: ActionTree<ChainStateInterface, StateInterface> = {
             // add 0.5% fee to the price
             commit('setRamPrice', (price / 0.995).toFixed(4));
         } catch (err) {
-            console.log('Error', err);
+            console.error(err);
         }
     },
 };

--- a/src/store/contract/actions.ts
+++ b/src/store/contract/actions.ts
@@ -7,9 +7,7 @@ export const actions: ActionTree<ContractStateInterface, StateInterface> = {
         commit('setContract', contractAddress);
         await dispatch('getContractInfo', contractAddress);
     },
-    getContractInfo({ commit }, contractAddress) {
-    //await getContract  via api
-        console.log(contractAddress); //unused var otherwise
+    getContractInfo({ commit }) {
         const response: { creator: string } = { creator: 'bob' }; //mock
         commit('setCreator', response.creator);
     },


### PR DESCRIPTION
# Fixes #623

## Description
The SendDialog component was setting TLOS as the default token to send, displaying the available amount on top of the field. The bug shows when the account has a zero TLOS balance because of a broken pointer access.

The bug was fixed and the new default behavior is to select TLOS if its balance is positive. Otherwise,  open the token selection dialog and force you to select one from the list.

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
