### PR TITLE
#507 | Auto refresh balances, misc bug fixes

### DIFF
--- a/src/api/fuel.ts
+++ b/src/api/fuel.ts
@@ -435,7 +435,7 @@ function validateActionsContent(
         if (expectedNewActions > 2) {
             validateActionsRamContent(signer, modifiedTransaction);
         }
-        return formatCurrency(totalFee, 4, 'TLOS');
+        return formatCurrency(totalFee, 4, 'TLOS', true);
     } else {
         return null;
     }

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -61,6 +61,7 @@ export default defineComponent({
                 data,
                 name: 'transfer',
             });
+            void store.dispatch('account/loadAccountData');
             context.emit('update-token-balances');
         };
 

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -103,12 +103,12 @@ export default defineComponent({
                 transfer: false,
                 stake_cpu_quantity:
                     parseFloat(this.cpuTokens) > 0
-                        ? formatCurrency(parseFloat(this.cpuTokens), 4, symbol)
-                        : `0 ${symbol}`,
+                        ? formatCurrency(parseFloat(this.cpuTokens), 4, symbol, true)
+                        : `0.0000 ${symbol}`,
                 stake_net_quantity:
                     parseFloat(this.netTokens) > 0
-                        ? formatCurrency(parseFloat(this.netTokens), 4, symbol)
-                        : `0 ${symbol}`,
+                        ? formatCurrency(parseFloat(this.netTokens), 4, symbol, true)
+                        : `0.0000 ${symbol}`,
             } as StakeResourcesTransactionData;
             try {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -84,6 +84,7 @@ export default defineComponent({
             selectOptions.value = options;
         });
 
+
         const netStake = ref<number>(0);
         const cpuStake = ref<number>(0);
 
@@ -161,6 +162,8 @@ export default defineComponent({
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 this.openTransaction = true;
             }
+
+            await this.$store.dispatch('account/loadAccountData');
         },
     },
 });

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -150,12 +150,12 @@ export default defineComponent({
                 transfer: false,
                 cpu_weight:
                     parseFloat(this.cpuTokens) > 0
-                        ? formatCurrency(parseFloat(this.cpuTokens), 4, symbol)
-                        : `0 ${symbol}`,
+                        ? formatCurrency(parseFloat(this.cpuTokens), 4, symbol, true)
+                        : `0.0000 ${symbol}`,
                 net_weight:
                     parseFloat(this.netTokens) > 0
-                        ? formatCurrency(parseFloat(this.netTokens), 4, symbol)
-                        : `0 ${symbol}`,
+                        ? formatCurrency(parseFloat(this.netTokens), 4, symbol, true)
+                        : `0.0000 ${symbol}`,
             });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {

--- a/src/components/staking/SavingsTab.vue
+++ b/src/components/staking/SavingsTab.vue
@@ -50,14 +50,14 @@ export default defineComponent({
         async function moveToSavings() {
             void store.dispatch('account/resetTransaction');
             if (
-                toSavingAmount.value === '0.0000' ||
+                toSavingAmount.value === '0' ||
                 toSavingAmount.value === '' ||
                 Number(toSavingAmount.value) >= eligibleStaked.value
             ) {
                 return;
             }
             await store.dispatch('account/moveToSavings', {
-                amount: toSavingAmount.value,
+                amount: toSavingAmount.value || '0',
             });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
@@ -68,14 +68,14 @@ export default defineComponent({
         async function moveFromSavings() {
             void store.dispatch('account/resetTransaction');
             if (
-                fromSavingAmount.value === '0.0000' ||
+                fromSavingAmount.value === '0' ||
                 fromSavingAmount.value === '' ||
                 Number(fromSavingAmount.value) >= assetToAmount(rexSavings.value)
             ) {
                 return;
             }
             await store.dispatch('account/moveFromSavings', {
-                amount: fromSavingAmount.value,
+                amount: fromSavingAmount.value || '0',
             });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
@@ -148,7 +148,7 @@ export default defineComponent({
                         v-model="toSavingAmount"
                         class="full-width"
                         standout="bg-deep-purple-2 text-white"
-                        placeholder='0.0000'
+                        placeholder='0'
                         :lazy-rules='true'
                         :rules="[ val => val >= 0 && val <= eligibleStaked  || 'Invalid amount.' ]"
                         type="text"
@@ -181,7 +181,7 @@ export default defineComponent({
                     <q-input
                         v-model="fromSavingAmount"
                         standout="bg-deep-purple-2 text-white"
-                        placeholder='0.0000'
+                        placeholder='0'
                         :lazy-rules='true'
                         :rules="[ val => val >= 0 && val <= assetToAmount(rexSavings)  || 'Invalid amount.' ]"
                         type="text"

--- a/src/components/staking/StakeFromResources.vue
+++ b/src/components/staking/StakeFromResources.vue
@@ -17,8 +17,8 @@ export default defineComponent({
         const symbol = ref<string>(chain.getSystemToken().symbol);
         const cpuTokens = ref<string>('');
         const netTokens = ref<string>('');
-        const cpuWithdraw = ref<string>('0.0000');
-        const netWithdraw = ref<string>('0.0000');
+        const cpuWithdraw = ref<string>('0');
+        const netWithdraw = ref<string>('0');
         const transactionId = ref<string>(store.state.account.TransactionId);
         const transactionError = ref<unknown>(store.state.account.TransactionError);
         const stakingAccount = computed(
@@ -56,16 +56,16 @@ export default defineComponent({
         async function stake() {
             void store.dispatch('account/resetTransaction');
             if (
-                (cpuTokens.value === '0.0000' && netTokens.value === '0.0000') ||
+                (cpuTokens.value === '0' && netTokens.value === '0') ||
                 Number(cpuTokens.value) >= Number(cpuWeight.value) ||
-                Number(netTokens.value) >=
-                Number(accountData.value.total_resources.net_weight)
+                Number(netTokens.value) >= Number(accountData.value.total_resources.net_weight)
             ) {
                 return;
             }
+
             await store.dispatch('account/stakeCpuNetRex', {
-                cpuAmount: cpuTokens.value,
-                netAmount: netTokens.value,
+                cpuAmount: cpuTokens.value || '0',
+                netAmount: netTokens.value || '0',
             });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
@@ -75,12 +75,12 @@ export default defineComponent({
 
         async function unstake() {
             void store.dispatch('account/resetTransaction');
-            if (cpuWithdraw.value === '0.0000' && netWithdraw.value === '0.0000') {
+            if (cpuWithdraw.value === '0' && netWithdraw.value === '0') {
                 return;
             }
             await store.dispatch('account/unstakeCpuNetRex', {
-                cpuAmount: cpuWithdraw.value,
-                netAmount: netWithdraw.value,
+                cpuAmount: cpuWithdraw.value || '0',
+                netAmount: netWithdraw.value || '0',
             });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
@@ -144,7 +144,7 @@ export default defineComponent({
                         dense
                         dark
                         standout="bg-deep-purple-2 text-white"
-                        placeholder='0.0000'
+                        placeholder='0'
                         type="text"
                         :lazy-rules='true'
                         :rules="[ val => val >= 0 && val <= cpuWeight.value  || 'Invalid amount.' ]"
@@ -165,7 +165,7 @@ export default defineComponent({
                         v-model="netTokens"
                         class="full-width"
                         standout="bg-deep-purple-2 text-white"
-                        placeholder='0.0000'
+                        placeholder='0'
                         :lazy-rules='true'
                         :rules="[ val =>  val >= 0 && val <= netWeight.value || 'Invalid amount.' ]"
                         type="text"

--- a/src/components/staking/StakingInfo.vue
+++ b/src/components/staking/StakingInfo.vue
@@ -13,7 +13,7 @@ export default defineComponent({
         const store = useStore();
         const symbol = ref<string>(chain.getSystemToken().symbol);
         const stakingAccount = ref<string>('');
-        const total = ref<string>('0.0000');
+        const total = ref<string>('0');
         const token = computed((): Token => store.state.chain.token);
         const accountData = computed((): API.v1.AccountObject => store.state.account.data);
         const liquidBalance = computed(() => accountData.value.core_liquid_balance);

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -556,7 +556,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
             commit('setTransactionError', e);
         }
     },
-    async moveToSavings({ commit, state }, { amount }) {
+    async moveToSavings({ commit, dispatch, state }, { amount }) {
         let transaction = null;
         const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX');
         const actions = [
@@ -586,11 +586,13 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }
     },
-    async moveFromSavings({ commit, state }, { amount }) {
+    async moveFromSavings({ commit, dispatch, state }, { amount }) {
         let transaction = null;
         const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX');
 
@@ -621,6 +623,8 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -463,7 +463,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
             commit('setTransactionError', e);
         }
     },
-    async buyRam({ commit, state }, { amount, receivingAccount }) {
+    async buyRam({ commit, dispatch, state }, { amount, receivingAccount }) {
         let transaction = null;
         const actions = [
             {
@@ -493,11 +493,12 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
         } catch (e) {
             commit('setTransactionError', e);
         }
     },
-    async buyRamBytes({ commit, state }, { amount, receivingAccount }) {
+    async buyRamBytes({ commit, dispatch, state }, { amount, receivingAccount }) {
         let transaction = null;
         const actions = [
             {
@@ -527,11 +528,12 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
         } catch (e) {
             commit('setTransactionError', e);
         }
     },
-    async sellRam({ commit, state }, { amount }) {
+    async sellRam({ commit, dispatch, state }, { amount }) {
         let transaction = null;
         const actions = [
             {
@@ -560,6 +562,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
         } catch (e) {
             commit('setTransactionError', e);
         }

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -201,7 +201,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     },
     async stakeRex({ commit, dispatch, state }, { amount }) {
         let transaction = null;
-        const quantityStr = formatCurrency(amount, 4, symbol);
+        const quantityStr = formatCurrency(amount, 4, symbol, true);
         const actions = [
             {
                 account: 'eosio',
@@ -257,8 +257,8 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         if (tokenRexBalance === 0) {
             return;
         }
-        const quantityStr = formatCurrency(amount, 4, symbol);
-        const rexToUnstake = formatCurrency(+amount / state.tlosRexRatio, 4);
+        const quantityStr = formatCurrency(amount, 4, symbol, true);
+        const rexToUnstake = formatCurrency(+amount / state.tlosRexRatio, 4, null, true);
 
         //   TODO check maturities
         const actions = [
@@ -310,7 +310,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     },
     async unstakeRexFund({ commit, state }, { amount }) {
         let transaction = null;
-        const quantityStr = formatCurrency(amount, 4, symbol);
+        const quantityStr = formatCurrency(amount, 4, symbol, true);
 
         const actions = [
             {
@@ -343,10 +343,10 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
             commit('setTransactionError', e);
         }
     },
-    async stakeCpuNetRex({ commit, state }, { cpuAmount, netAmount }) {
+    async stakeCpuNetRex({ commit, dispatch, state }, { cpuAmount, netAmount }) {
         let transaction = null;
-        const quantityStrCPU = formatCurrency(cpuAmount, 4, symbol);
-        const quantityStrNET = formatCurrency(netAmount, 4, symbol);
+        const quantityStrCPU = formatCurrency(cpuAmount, 4, symbol, true);
+        const quantityStrNET = formatCurrency(netAmount, 4, symbol, true);
         const actions = [
             {
                 account: 'eosio',
@@ -376,14 +376,16 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }
     },
-    async unstakeCpuNetRex({ commit, state }, { cpuAmount, netAmount }) {
+    async unstakeCpuNetRex({ commit, dispatch, state }, { cpuAmount, netAmount }) {
         let transaction = null;
-        const quantityStrCPU = formatCurrency(cpuAmount, 4, symbol);
-        const quantityStrNET = formatCurrency(netAmount, 4, symbol);
+        const quantityStrCPU = formatCurrency(cpuAmount, 4, symbol, true);
+        const quantityStrNET = formatCurrency(netAmount, 4, symbol, true);
         const actions = [
             {
                 account: 'eosio',
@@ -413,6 +415,8 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }
@@ -562,7 +566,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     },
     async moveToSavings({ commit, dispatch, state }, { amount }) {
         let transaction = null;
-        const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX');
+        const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX', true);
         const actions = [
             {
                 account: 'eosio',
@@ -598,7 +602,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
     },
     async moveFromSavings({ commit, dispatch, state }, { amount }) {
         let transaction = null;
-        const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX');
+        const rexToUnstake = formatCurrency((+amount / state.tlosRexRatio), 4, 'REX', true);
 
         const actions = [
             {

--- a/src/store/account/actions.ts
+++ b/src/store/account/actions.ts
@@ -199,7 +199,7 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
         }
         return transaction;
     },
-    async stakeRex({ commit, state }, { amount }) {
+    async stakeRex({ commit, dispatch, state }, { amount }) {
         let transaction = null;
         const quantityStr = formatCurrency(amount, 4, symbol);
         const actions = [
@@ -243,11 +243,13 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }
     },
-    async unstakeRex({ commit, state }, { amount }) {
+    async unstakeRex({ commit, dispatch, state }, { amount }) {
         let transaction = null;
         const tokenRexBalance = state.rexbal.rex_balance
             ? Number(state.rexbal.rex_balance.split(' ')[0])
@@ -300,6 +302,8 @@ export const actions: ActionTree<AccountStateInterface, StateInterface> = {
                 },
             );
             commit('setTransaction', transaction.transactionId);
+            void dispatch('loadAccountData');
+            void dispatch('updateRexData', { account: state.accountName });
         } catch (e) {
             commit('setTransactionError', e);
         }

--- a/src/store/chain/actions.ts
+++ b/src/store/chain/actions.ts
@@ -89,7 +89,7 @@ export const actions: ActionTree<ChainStateInterface, StateInterface> = {
             const quote = Number(rammarket.quote.balance.split(' ')[0]);
             const price = (quote * 1000) / (base - 1000);
             // add 0.5% fee to the price
-            const formattedPrice = formatCurrency((price / 0.995), 4);
+            const formattedPrice = formatCurrency((price / 0.995), 4, null, true);
 
             commit('setRamPrice', formattedPrice);
         } catch (err) {

--- a/src/store/resources/actions.ts
+++ b/src/store/resources/actions.ts
@@ -57,8 +57,8 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
             const self_net_weight = Number(accountData.self_delegated_bandwidth?.cpu_weight.value ?? 0);
             const self_cpu_weight = Number(accountData.self_delegated_bandwidth?.net_weight.value ?? 0);
 
-            const self_net_asset = formatCurrency(self_net_weight, precision, symbol);
-            const self_cpu_asset = formatCurrency(self_cpu_weight, precision, symbol);
+            const self_net_asset = formatCurrency(self_net_weight, precision, symbol, true);
+            const self_cpu_asset = formatCurrency(self_cpu_weight, precision, symbol, true);
 
             const selfStaked: DelegatedResources = {
                 from: account,
@@ -75,8 +75,8 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
             const from_others_net_weight = total_net_weight - self_net_weight;
             const from_others_cpu_weight = total_cpu_weight - self_cpu_weight;
 
-            const from_others_net_asset = formatCurrency(from_others_net_weight, precision, symbol);
-            const from_others_cpu_asset = formatCurrency(from_others_cpu_weight, precision, symbol);
+            const from_others_net_asset = formatCurrency(from_others_net_weight, precision, symbol, true);
+            const from_others_cpu_asset = formatCurrency(from_others_cpu_weight, precision, symbol, true);
 
             const fromOthers: DelegatedResources = {
                 from: 'not-available',

--- a/src/store/resources/actions.ts
+++ b/src/store/resources/actions.ts
@@ -54,8 +54,8 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
             const accountData = store.rootState.account.data;
 
             // self staked resources
-            const self_net_weight = Number(accountData.self_delegated_bandwidth?.cpu_weight.value ?? 0);
-            const self_cpu_weight = Number(accountData.self_delegated_bandwidth?.net_weight.value ?? 0);
+            const self_net_weight = Number(accountData.self_delegated_bandwidth?.net_weight.value ?? 0);
+            const self_cpu_weight = Number(accountData.self_delegated_bandwidth?.cpu_weight.value ?? 0);
 
             const self_net_asset = formatCurrency(self_net_weight, precision, symbol, true);
             const self_cpu_asset = formatCurrency(self_cpu_weight, precision, symbol, true);

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -44,9 +44,10 @@ export function formatCurrency(
         amountAsString = (() => {
             const [integer, fraction] = amountAsString.split('.');
 
-            return `${(+integer).toLocaleString()}.${fraction}`;
+            return `${(+integer).toLocaleString('en')}.${fraction}`;
         })();
     }
+
 
     if (+amountAsString === 0 && !skipPrettyPrinting) {
         amountAsString = '0';

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -17,14 +17,13 @@ export function isValidTransactionHex(hexString: string): boolean {
  * @param {number|string} amount - the quantity of the currency
  * @param {number} precision - the number of decimal places to be preserved
  * @param {string} symbol - optional, the symbol of the currency
- * @param {boolean} preserveTrailingZeroes - optional, whether to prevent the trimming of trailing zeroes in the case of
- *      a zero value for cases where precision is critical, e.g. if true '0.0000 TLOS' will not be converted to '0 TLOS'
+ * @param {boolean} skipPrettyPrinting - optional, whether to prevent commification & the trimming of trailing zeroes
  */
 export function formatCurrency(
     amount: string | number,
     precision: number,
     symbol?: string,
-    preserveTrailingZeroes?: boolean,
+    skipPrettyPrinting?: boolean,
 ): string {
     const floatingPointNumberRegex = /^-?(0|[1-9]\d*)(\.\d+)?$/;
     const amountIsValid =
@@ -40,14 +39,16 @@ export function formatCurrency(
     // ensure correct precision
     amountAsString = (+amountAsString).toFixed(precision);
 
-    // commify
-    amountAsString = (() => {
-        const [integer, fraction] = amountAsString.split('.');
+    if (!skipPrettyPrinting) {
+        // commify
+        amountAsString = (() => {
+            const [integer, fraction] = amountAsString.split('.');
 
-        return `${(+integer).toLocaleString()}.${fraction}`;
-    })();
+            return `${(+integer).toLocaleString()}.${fraction}`;
+        })();
+    }
 
-    if (+amountAsString === 0 && !preserveTrailingZeroes) {
+    if (+amountAsString === 0 && !skipPrettyPrinting) {
         amountAsString = '0';
     }
 

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -17,11 +17,14 @@ export function isValidTransactionHex(hexString: string): boolean {
  * @param {number|string} amount - the quantity of the currency
  * @param {number} precision - the number of decimal places to be preserved
  * @param {string} symbol - optional, the symbol of the currency
+ * @param {boolean} preserveTrailingZeroes - optional, whether to prevent the trimming of trailing zeroes in the case of
+ *      a zero value for cases where precision is critical, e.g. if true '0.0000 TLOS' will not be converted to '0 TLOS'
  */
 export function formatCurrency(
     amount: string | number,
     precision: number,
     symbol?: string,
+    preserveTrailingZeroes?: boolean,
 ): string {
     const floatingPointNumberRegex = /^-?(0|[1-9]\d*)(\.\d+)?$/;
     const amountIsValid =
@@ -44,7 +47,7 @@ export function formatCurrency(
         return `${(+integer).toLocaleString()}.${fraction}`;
     })();
 
-    if (+amountAsString === 0) {
+    if (+amountAsString === 0 && !preserveTrailingZeroes) {
         amountAsString = '0';
     }
 

--- a/test/jest/__tests__/store/resources/actions.spec.ts
+++ b/test/jest/__tests__/store/resources/actions.spec.ts
@@ -276,8 +276,8 @@ describe('Store - Resources Actions', () => {
             expect(commit).toHaveBeenCalledWith('setDelegatedFromOthers', {
                 from: 'not-available',
                 to: anotheraccount,
-                net_weight: '0 TLOS',
-                cpu_weight: '0 TLOS',
+                net_weight: '0.0000 TLOS',
+                cpu_weight: '0.0000 TLOS',
             });
             expect(commit).toHaveBeenCalledWith('setSelfStaked', {
                 from: anotheraccount,

--- a/test/jest/__tests__/utils/string-utils.spec.ts
+++ b/test/jest/__tests__/utils/string-utils.spec.ts
@@ -114,7 +114,8 @@ describe('string-utils utility functions', () => {
             expect(formatCurrency(0, 4, 'TLOS')).toBe('0 TLOS');
         });
 
-        it('should not trim trailing zeroes when preserveTrailingZeroes is true', () => {
+        it('should pretty print when skipPrettyPrinting is true', () => {
+            // zero-trimming should be skipped
             expect(formatCurrency('0.0000', 2, null, true)).toBe('0.00');
             expect(formatCurrency('0.0000', 4, null, true)).toBe('0.0000');
             expect(formatCurrency('0.0000', 2, 'USD', true)).toBe('0.00 USD');
@@ -123,6 +124,9 @@ describe('string-utils utility functions', () => {
             expect(formatCurrency('0', 4, null, true)).toBe('0.0000');
             expect(formatCurrency('0', 2, 'USD', true)).toBe('0.00 USD');
             expect(formatCurrency('0', 4, 'TLOS', true)).toBe('0.0000 TLOS');
+
+            // commification should be skipped
+            expect(formatCurrency('1000', 4, 'TLOS', true)).toBe('1000.0000 TLOS');
         });
 
         it('should throw an error when supplied an invalid amount', () => {

--- a/test/jest/__tests__/utils/string-utils.spec.ts
+++ b/test/jest/__tests__/utils/string-utils.spec.ts
@@ -114,6 +114,17 @@ describe('string-utils utility functions', () => {
             expect(formatCurrency(0, 4, 'TLOS')).toBe('0 TLOS');
         });
 
+        it('should not trim trailing zeroes when preserveTrailingZeroes is true', () => {
+            expect(formatCurrency('0.0000', 2, null, true)).toBe('0.00');
+            expect(formatCurrency('0.0000', 4, null, true)).toBe('0.0000');
+            expect(formatCurrency('0.0000', 2, 'USD', true)).toBe('0.00 USD');
+            expect(formatCurrency('0.0000', 4, 'TLOS', true)).toBe('0.0000 TLOS');
+            expect(formatCurrency('0', 2, null, true)).toBe('0.00');
+            expect(formatCurrency('0', 4, null, true)).toBe('0.0000');
+            expect(formatCurrency('0', 2, 'USD', true)).toBe('0.00 USD');
+            expect(formatCurrency('0', 4, 'TLOS', true)).toBe('0.0000 TLOS');
+        });
+
         it('should throw an error when supplied an invalid amount', () => {
             const inputs = [
                 '',


### PR DESCRIPTION
# Fixes #507 

## Description
This PR makes it so all balances (except unstake - #662 has been created for this) refresh after an action has been taken. It also fixes a bug where the net and CPU balances are swapped on the unstake tab. 

it also fixes a bug where some transactions would fail due to having a zero in an input. this bug was due to handling of `0.0000 TLOS` being truncated to `0 TLOS` which causes the tx to fail

it also fixes a bug where some txns would fail because large numbers were commified when they should not have been

## Test scenarios

- go to https://deploy-preview-663--obe-staging.netlify.app/
- sign in using anchor with an account which has various balances (staked to net, staked to cpu, savings, etc)
- go through all of the tabs in Send, Resources, and Staking (REX) sections of the account page. for each tab, try completing a transaction (e.g. sending a token to another account)
    - after successfully completing the action, the balances should update to reflect new changes
- go to Staking -> stake from cpu/net
- try to stake some amount of CPU but leave NET at 0
    - the action should succeed (in codebase now, this will fail because of the 0 handling bug)
- go to Resources -> add CPU/NET
- try adding some CPU but leave NET at 0
    - action should succeed
- go to Remove CPU/NET
    - note that the values over the inputs for CPU and NET match the values at the top of the page (they are swapped in current codebase)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
