### PR TITLE
#650 | Pagination flickering

### DIFF
--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -300,6 +300,7 @@ export default defineComponent({
                 });
                 tableData = response.data.actions;
                 totalRows.value = response.data.total.value;
+                console.log(response.data.total.value);
             }
 
             if (tableData) {
@@ -450,7 +451,7 @@ export default defineComponent({
             void updateLiveTransactionState();
         });
 
-        // create a watch for pagination and make sure it is called inmediately
+        // create a watch for pagination and make sure it is called immediately
         watch(
             () => pagination.value,
             async () => {
@@ -486,7 +487,7 @@ export default defineComponent({
             drop.hide();
         };
 
-        const moveTablePage = async (ref: unknown, dir: 'next' | 'prev' | 'first' | 'last') => {
+        const moveTablePage = (ref: unknown, dir: 'next' | 'prev' | 'first' | 'last') => {
             const table: QTable = ref as QTable;
             if (dir === 'next') {
                 table.nextPage();
@@ -495,7 +496,7 @@ export default defineComponent({
             } else if (dir === 'first') {
                 table.firstPage();
             } else if (dir === 'last') {
-                await applyPagination(lastPage.value, null);
+                void changePagination(lastPage.value, paginationSettings.value.rowsPerPage);
             }
         };
 
@@ -575,6 +576,7 @@ export default defineComponent({
                             class="text-no-wrap"
                             left-label
                             label="Live transactions"
+                            :disable="paginationSettings.page !== 1"
                         />
                     </div>
                 </div>
@@ -865,7 +867,7 @@ export default defineComponent({
 
                 <small>
                     Page {{ paginationSettings.page }}
-                    {{ showPaginationExtras ? (lastPage === 0 ? ` of 1` : ` of ${lastPage}`) : '' }}
+                    {{ (showPaginationExtras && enableLiveTransactions === false) ? (lastPage === 0 ? ` of 1` : ` of ${lastPage}`) : '' }}
                 </small>
 
                 <q-btn
@@ -880,7 +882,7 @@ export default defineComponent({
                 </q-btn>
 
                 <q-btn
-                    v-if="showPaginationExtras"
+                    v-if="showPaginationExtras && enableLiveTransactions === false"
                     size="sm"
                     color="primary"
                     outline


### PR DESCRIPTION
# Fixes #650

## Description

This PR is a partial fix for flickering pagination. the issue is that the backend returns a different number of results for the same query at random (try going [here](https://testnet.telos.net/v2/history/get_actions?sort=desc&limit=10&account=eztestnet123) and reloading several times, see results vary). For now this PR hides the total number of pages when live transactions is enabled (live transactions = new query every few seconds = changing results because of bug). it also fixes the Last Page button to disable Live Transactions, and disables Live Transactions toggle when not on the first page

## Test scenarios

- go to https://deploy-preview-665--open-block-explorer.netlify.app/account/eztestnet123 and scroll to the transaction table
- disable live transactions
- click Last Page
    - results should no longer jump around
    - the pagination in the URL should be updated (this is broken in prod)

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file
-   [x] I have created a new issue with the required translations for the currently supported languages
