### PR TITLE
full incorporation of the new AntelopeStore.resource into StakeTab and UnstakeTab components

### DIFF
--- a/src/components/resources/ResourcesInfo.vue
+++ b/src/components/resources/ResourcesInfo.vue
@@ -24,7 +24,7 @@ export default defineComponent({
             Number(accountData.value.ram_quota) -
             Number(accountData.value.ram_usage),
         );
-        const delegatedResources = computed(() => {
+        const delegatedByOthers = computed(() => {
             const totalStakedResources =
                 Number(accountData.value.cpu_weight.value) /
                     Math.pow(10, token.value.precision) +
@@ -43,6 +43,9 @@ export default defineComponent({
                 );
             return totalStakedResources - selfStakedResources;
         });
+        const delegatedToOthers = computed(
+            (): number => store.state.resources.toOthersAggregated,
+        );
 
         const accountTotal = computed(() => {
             let value = 0;
@@ -78,7 +81,8 @@ export default defineComponent({
             token,
             ramPrice,
             ramAvailable,
-            delegatedResources,
+            delegatedByOthers,
+            delegatedToOthers,
             accountTotal,
             currentCpu,
             currentNet,
@@ -118,16 +122,20 @@ export default defineComponent({
             <div class="col-xs-12 col-sm-6 q-px-lg q-pb-sm">
                 <div class="row">
                     <div class="col-7 text-weight-light">DELEGATED BY OTHERS</div>
-                    <div class="col-5 text-right text-bold">{{ formatValue(delegatedResources) }}</div>
+                    <div class="col-5 text-right text-bold">{{ formatValue(delegatedByOthers) }}</div>
+                </div>
+                <div class="row q-pt-sm">
+                    <div class="col-7 text-weight-light">DELEGATED TO OTHERS</div>
+                    <div class="col-5 text-right text-bold">{{ formatValue(delegatedToOthers) }}</div>
                 </div>
                 <div class="row q-pt-sm">
                     <div class="col-7 text-weight-light">REFUNDING</div>
                     <div class="col-5 text-right text-bold">{{ formatValue(totalRefund) }}</div>
                 </div>
-                <div class="row q-pt-sm">
+                <!--div class="row q-pt-sm">
                     <div class="col-7 text-weight-light">RAM PRICE</div>
                     <div class="col-5 text-right text-bold">{{ramPrice}} {{token.symbol}}/KB</div>
-                </div>
+                </div-->
             </div>
         </div>
     </div>

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -1,12 +1,10 @@
 <script lang="ts">
 import { defineComponent, ref, computed } from 'vue';
-import { useStore } from 'src/store';
 import { mapActions } from 'vuex';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { formatCurrency, isValidAccount } from 'src/utils/string-utils';
-import { API } from '@greymass/eosio';
-import { StakeResourcesTransactionData } from 'src/types';
+import { useAntelopeStore } from 'src/store/antelope.store';
 
 const chain = getChain();
 const symbol = chain.getSystemToken().symbol;
@@ -17,7 +15,7 @@ export default defineComponent({
         ViewTransaction,
     },
     setup() {
-        const store = useStore();
+        const store = useAntelopeStore();
         const openTransaction = ref<boolean>(false);
         const stakingAccount = ref<string>(store.state.account.accountName || '');
         const accountTotal = computed((): string =>
@@ -66,7 +64,8 @@ export default defineComponent({
             stakingAccount,
             cpuTokens,
             netTokens,
-            ...mapActions({ sendAction: 'account/sendAction' }),
+            // ...mapActions({ sendAction: 'account/sendAction' }),
+            ...mapActions({ delegateResources: 'resources/delegateResources' }),
             transactionId: ref<string>(null),
             transactionError: null,
             formatDec,
@@ -97,46 +96,22 @@ export default defineComponent({
                 this.$q.notify('Enter valid value for CPU or NET to stake');
                 return;
             }
-            const data = {
-                from: this.$store.state.account.accountName.toLowerCase(),
-                receiver: this.stakingAccount.toLowerCase(),
+            await this.delegateResources({
+                from: this.$store.state.account.accountName,
+                to: this.stakingAccount.toLowerCase().trim(),
                 transfer: false,
-                stake_cpu_quantity:
+                cpu_weight:
                     parseFloat(this.cpuTokens) > 0
                         ? formatCurrency(parseFloat(this.cpuTokens), 4, symbol, true)
                         : `0.0000 ${symbol}`,
-                stake_net_quantity:
+                net_weight:
                     parseFloat(this.netTokens) > 0
                         ? formatCurrency(parseFloat(this.netTokens), 4, symbol, true)
                         : `0.0000 ${symbol}`,
-            } as StakeResourcesTransactionData;
-            try {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                this.transactionId = (
-                    await this.sendAction({
-                        account: 'eosio',
-                        name: 'delegatebw',
-                        data,
-                    })
-                ).transactionId as string;
-                this.$store.commit('account/setTransaction', this.transactionId);
-            } catch (e) {
-                this.transactionError = e;
-                this.$store.commit('account/setTransactionError', e);
-            }
-            await this.loadAccountData();
+            });
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 this.openTransaction = true;
-            }
-        },
-        async loadAccountData(): Promise<void> {
-            let data: API.v1.AccountObject;
-            try {
-                data = await this.$api.getAccount(this.stakingAccount);
-                this.$store.commit('account/setAccountData', data);
-            } catch (e) {
-                return;
             }
         },
     },

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -64,7 +64,6 @@ export default defineComponent({
             stakingAccount,
             cpuTokens,
             netTokens,
-            // ...mapActions({ sendAction: 'account/sendAction' }),
             ...mapActions({ delegateResources: 'resources/delegateResources' }),
             transactionId: ref<string>(null),
             transactionError: null,

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -62,8 +62,6 @@ export default defineComponent({
         const isUpdating = computed(() => store.resources.isLoading('updateResources'));
         const isUnstaking = computed(() => store.resources.isLoading('undelegateResources'));
         const loading = computed(() => store.resources.getLoading());
-
-        // const selectOptions = ref<{label:string, value:DelegatedResources}[]>([]);
         const selectModel = ref<{label:string, value:DelegatedResources}>({ label: '', value: null });
         const receiverAccount = computed((): string => selectModel.value?.value?.to);
 

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -63,27 +63,27 @@ export default defineComponent({
         const isUnstaking = computed(() => store.resources.isLoading('undelegateResources'));
         const loading = computed(() => store.resources.getLoading());
 
-        const selectOptions = ref<{label:string, value:DelegatedResources}[]>([]);
+        // const selectOptions = ref<{label:string, value:DelegatedResources}[]>([]);
         const selectModel = ref<{label:string, value:DelegatedResources}>({ label: '', value: null });
         const receiverAccount = computed((): string => selectModel.value?.value?.to);
 
-        void store.resources.updateResources().then(() => {
-            const selfStaked = store.resources.getSelfStaked();
-            if (selfStaked) {
-                selectModel.value = {
-                    label: selfStaked?.to,
-                    value: selfStaked,
-                };
-            }
-
+        const selectOptions = computed(() => {
             const options = delegatedList.value?.map(item => ({
                 label: item.to,
                 value: item,
             })) ?? [];
-
-            selectOptions.value = options;
+            return options;
         });
 
+        void store.resources.updateResources({}).then(() => {
+            const selfStaked = store.resources.getSelfStaked();
+            if (selfStaked) {
+                selectModel.value = {
+                    label: (selfStaked?.to ?? 'unknown'),
+                    value: selfStaked,
+                };
+            }
+        });
 
         const netStake = ref<number>(0);
         const cpuStake = ref<number>(0);
@@ -112,10 +112,13 @@ export default defineComponent({
     watch: {
         selectModel: {
             handler() {
-                this.netStake = this.assetToAmount((this.selectModel.value as DelegatedResources)?.net_weight.toString());
-                this.cpuStake = this.assetToAmount((this.selectModel.value as DelegatedResources)?.cpu_weight.toString());
-                this.netTokens = '0';
-                this.cpuTokens = '0';
+                this.update();
+            },
+            deep: true,
+        },
+        selectOptions: {
+            handler() {
+                this.update();
             },
             deep: true,
         },
@@ -138,6 +141,18 @@ export default defineComponent({
         },
     },
     methods: {
+        update(): void {
+
+            const current = this.selectOptions.find(item => item.value.to === (this.selectModel?.value?.to ?? ''));
+            if (current) {
+                this.selectModel = current;
+            }
+
+            this.netStake = this.assetToAmount((this.selectModel.value as DelegatedResources)?.net_weight.toString());
+            this.cpuStake = this.assetToAmount((this.selectModel.value as DelegatedResources)?.cpu_weight.toString());
+            this.netTokens = '0';
+            this.cpuTokens = '0';
+        },
         async sendTransaction(): Promise<void> {
             this.transactionError = '';
             if (parseFloat(this.cpuTokens) <= 0 && parseFloat(this.netTokens) <= 0) {
@@ -162,8 +177,6 @@ export default defineComponent({
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 this.openTransaction = true;
             }
-
-            await this.$store.dispatch('account/loadAccountData');
         },
     },
 });

--- a/src/store/antelope.store.ts
+++ b/src/store/antelope.store.ts
@@ -2,11 +2,12 @@ import { StateInterface, useStore } from 'src/store';
 import { ResourcesAPI } from 'src/store/resources';
 import { DelegatedResources } from 'src/store/resources/state';
 import { Ref } from 'vue';
-import { DispatchOptions } from 'vuex';
+import { CommitOptions, DispatchOptions } from 'vuex';
 
 interface GettersInterface {
     'resources/getDelegatedToOthers': DelegatedResources[];
     'resources/getDelegatedFromOthers': Ref<DelegatedResources | null>;
+    'resources/getDelegatedToOthersAggregated': number;
     'resources/getSelfStaked': DelegatedResources | null;
     'resources/getLoading': string[];
     'resources/isLoading': (name: string) => boolean;
@@ -16,6 +17,7 @@ export interface AntelopeStore {
     resources: ResourcesAPI;
     state: StateInterface;
     dispatch: (t: string, p?: unknown, o?: DispatchOptions) => Promise<unknown>;
+    commit: (type: string, payload?: unknown, options?: CommitOptions) => void;
 }
 
 export function useAntelopeStore(): AntelopeStore {
@@ -27,11 +29,12 @@ export function useAntelopeStore(): AntelopeStore {
             getDelegatedToOthers: (): DelegatedResources[] => getters['resources/getDelegatedToOthers'],
             getDelegatedFromOthers: ():Ref<DelegatedResources> => getters['resources/getDelegatedFromOthers'],
             getSelfStaked: ():DelegatedResources => getters['resources/getSelfStaked'],
+            getDelegatedToOthersAggregated: ():number => getters['resources/getDelegatedToOthersAggregated'],
             getLoading: ():string[] => getters['resources/getLoading'],
             isLoading: (funcname: string) => getters['resources/isLoading'](funcname),
 
             // actions
-            updateResources: (force?:boolean) => store.dispatch('resources/updateResources', force),
+            updateResources: (payload: {account?: string, force?:boolean}) => store.dispatch('resources/updateResources', payload),
             updateSelfStaked: (account: string) => store.dispatch('resources/updateSelfStaked', account),
             updateDelegatedToOthers: (account: string) => store.dispatch('resources/updateDelegatedToOthers', account),
             delegateResources: (order: DelegatedResources) => store.dispatch('resources/delegateResources', order),
@@ -40,5 +43,7 @@ export function useAntelopeStore(): AntelopeStore {
         state,
         dispatch: ((type: string, payload?: unknown, options?: DispatchOptions): Promise<unknown> =>
             store.dispatch(type, payload, options)),
+        commit: ((type: string, payload?: unknown, options?: CommitOptions): void =>
+            store.commit(type, payload, options)),
     };
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -27,24 +27,24 @@ import { ResourcesStateInterface } from 'src/store/resources/state';
  */
 
 export interface StateInterface {
-  // Define your own store structure, using submodules if needed
-  contract: ContractStateInterface;
-  chain: ChainStateInterface;
-  account: AccountStateInterface;
-  transaction: TransactionStateInterface;
-  resources: ResourcesStateInterface;
+    // Define your own store structure, using submodules if needed
+    contract: ContractStateInterface;
+    chain: ChainStateInterface;
+    account: AccountStateInterface;
+    transaction: TransactionStateInterface;
+    resources: ResourcesStateInterface;
 }
 
 // provide typings for `this.$store`
 declare module '@vue/runtime-core' {
-  interface ComponentCustomProperties {
-    $store: VuexStore<StateInterface>;
-  }
+    interface ComponentCustomProperties {
+        $store: VuexStore<StateInterface>;
+    }
 }
 
 // provide typings for `useStore` helper
 export const storeKey: InjectionKey<VuexStore<StateInterface>> =
-  Symbol('vuex-key');
+    Symbol('vuex-key');
 
 export default store(function () {
     const Store = createStore<StateInterface>({
@@ -60,7 +60,6 @@ export default store(function () {
         // for dev mode and --debug builds only
         strict: !!process.env.DEBUGGING,
     });
-
     return Store;
 });
 

--- a/src/store/resources/actions.ts
+++ b/src/store/resources/actions.ts
@@ -3,7 +3,6 @@ import { StateInterface } from 'src/store/index';
 import { DelegatedResources, ResourcesStateInterface } from 'src/store/resources/state';
 import { GetTableRowsParams } from 'src/types';
 import { api } from 'src/api';
-import { SignTransactionResponse } from 'universal-authenticator-library';
 import { getChain } from 'src/config/ConfigManager';
 import { formatCurrency } from 'src/utils/string-utils';
 
@@ -14,21 +13,22 @@ const precision = chain.getSystemToken().precision;
 export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
 
     // general update action to assert all resources related data is loaded for the current account
-    async updateResources(store, force = false) {
+    async updateResources(store, { account, force }) {
+        const currentAccount = (account as string) ?? (store.rootState.account.accountName);
         try {
             store.commit('setLoading', 'updateResources');
             store.commit('setForceUpdate', force);
             if (
-                store.state.currentAccount !== store.rootState.account.accountName ||
+                store.state.currentAccount !== currentAccount ||
                 !store.rootState.account.data ||
                 force
             ) {
                 // dispatch updateSelfStaked and updateDelegatedToOthers actions in parallel awaiting for both to finish
                 await Promise.all([
-                    store.dispatch('updateSelfStaked', store.rootState.account.accountName),
-                    store.dispatch('updateDelegatedToOthers', store.rootState.account.accountName),
+                    store.dispatch('updateSelfStaked', currentAccount),
+                    store.dispatch('updateDelegatedToOthers', currentAccount),
                 ]);
-                store.commit('setCurrentAccount', store.rootState.account.accountName);
+                store.commit('setCurrentAccount', currentAccount);
             }
         } catch (err) {
             console.error('Error:', err);
@@ -45,7 +45,8 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
             if (
                 store.state.currentAccount !== account ||
                 store.state.selfStaked?.from !== account ||
-                store.state.selfStaked?.to !== account
+                store.state.selfStaked?.to !== account ||
+                store.state.forceUpdate
             ) {
                 // dispatch loadAccountData action from account module
                 await store.dispatch('account/loadAccountData', account, { root: true });
@@ -112,8 +113,20 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
                 }
             ).rows;
 
+            const delegatedToOthers = delegated.filter(item => item.to !== account);
+            const delegatedToOthersNet = delegatedToOthers.reduce(
+                (acc, item) => acc + parseFloat(item.net_weight),
+                0,
+            );
+            const delegatedToOthersCpu = delegatedToOthers.reduce(
+                (acc, item) => acc + parseFloat(item.cpu_weight),
+                0,
+            );
+            const totalDelegatedToOthers = delegatedToOthersCpu + delegatedToOthersNet;
+
             commit('setCurrentAccount', account);
             commit('setDelegatedToOthers', delegated);
+            commit('setDelegatedToOthersAggregated', totalDelegatedToOthers);
         } catch (err) {
             console.error('Error:', err);
         } finally {
@@ -128,7 +141,7 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
             commit('setLoading', 'delegateResources');
 
             // calculate the total amount
-            const amount = Number(net_weight) + Number(cpu_weight);
+            const amount = Number(net_weight ?? '0') + Number(cpu_weight ?? '0');
 
             const actions = [
                 {
@@ -150,8 +163,9 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
                     },
                 },
             ];
-            const transaction = (await dispatch('sendTransaction', actions)) as undefined as SignTransactionResponse;
-            commit('setTransaction', transaction.transactionId);
+
+            await dispatch('account/sendTransaction', actions, { root: true });
+            await dispatch('updateResources', { account:from, force: true });
         } catch (e) {
             commit('setTransactionError', e);
         } finally {
@@ -184,17 +198,25 @@ export const actions: ActionTree<ResourcesStateInterface, StateInterface> = {
                 },
             ];
             await dispatch('account/sendTransaction', actions, { root: true });
+            await dispatch('updateResources', { account:from, force: true });
         } catch (e) {
             console.error('Error', e);
         } finally {
             commit('unsetLoading', 'undelegateResources');
         }
     },
+
+    // reset interlad data when there's no logged in account
+    resetResources({ commit }) {
+        commit('setDelegatedFromOthers', null);
+        commit('setDelegatedToOthers', []);
+        commit('setSelfStaked', null);
+    },
 };
 
 // include all actions in the interface as callable full-typed functions
 export interface ResourcesActions {
-    updateResources: (force?: boolean) => Promise<void>;
+    updateResources: (payload: {account?:string, force?: boolean}) => Promise<void>;
     updateSelfStaked: (account: string) => Promise<void>;
     updateDelegatedToOthers: (account: string) => Promise<void>;
     delegateResources: (order: DelegatedResources) => Promise<void>;

--- a/src/store/resources/getters.ts
+++ b/src/store/resources/getters.ts
@@ -10,6 +10,11 @@ export const getters: GetterTree<ResourcesStateInterface, StateInterface> = {
         return store.toOthers ?? [];
     },
 
+    // get list of delegates resources to other accounts
+    getDelegatedToOthersAggregated(store: ResourcesStateInterface): number {
+        return store.toOthersAggregated ?? 0;
+    },
+
     // get list of delegates resources from other accounts
     getDelegatedFromOthers(store: ResourcesStateInterface): DelegatedResources | null {
         return store.fromOthers;
@@ -36,6 +41,7 @@ export const getters: GetterTree<ResourcesStateInterface, StateInterface> = {
 export interface ResourcesGetters {
     getDelegatedToOthers: () => DelegatedResources[];
     getDelegatedFromOthers: () => Ref<DelegatedResources | null>;
+    getDelegatedToOthersAggregated: () => number;
     getSelfStaked: () => DelegatedResources | null;
     getLoading: () => string[];
     isLoading: (name: string) => boolean;

--- a/src/store/resources/mutations.ts
+++ b/src/store/resources/mutations.ts
@@ -15,6 +15,10 @@ export const mutations: MutationTree<ResourcesStateInterface> = {
         state.toOthers = delegated as DelegatedResources[];
     },
 
+    setDelegatedToOthersAggregated(state: ResourcesStateInterface, aggregated) {
+        state.toOthersAggregated = aggregated as number;
+    },
+
     setSelfStaked(state: ResourcesStateInterface, delegated) {
         state.selfStaked = delegated as DelegatedResources;
     },
@@ -34,5 +38,6 @@ export const mutations: MutationTree<ResourcesStateInterface> = {
     setForceUpdate(state: ResourcesStateInterface, forceUpdate: boolean) {
         state.forceUpdate = forceUpdate;
     },
+
 
 };

--- a/src/store/resources/state.ts
+++ b/src/store/resources/state.ts
@@ -10,6 +10,7 @@ export interface DelegatedResources {
 export interface ResourcesStateInterface {
     currentAccount: string;
     toOthers: DelegatedResources[];
+    toOthersAggregated: number;
     fromOthers: DelegatedResources | null;
     selfStaked: DelegatedResources | null;
     loading: string[];
@@ -20,6 +21,7 @@ export function state(): ResourcesStateInterface {
     return {
         currentAccount: '',
         toOthers: [],
+        toOthersAggregated: 0,
         fromOthers: null,
         selfStaked: null,
         loading: [],

--- a/test/jest/__tests__/store/antelope.store.spec.ts
+++ b/test/jest/__tests__/store/antelope.store.spec.ts
@@ -117,7 +117,7 @@ describe('AntilopeStore', () => {
 
         describe('resources.updateResources()', () => {
             it('should dispatch: resources/updateResources', () => {
-                const result = store.resources.updateResources();
+                const result = store.resources.updateResources({});
                 const expected = Promise.resolve();
                 expect(result).toEqual(expected);
             });


### PR DESCRIPTION
# Fixes #662

## Description
@EJSG pointed out that after the transaction to undelegated resources was successfully executed, the account data didn't refresh automatically and indeed, that was happening. So I took the opportunity to fully incorporate the new `AntelopeStore` prototype into the two components related to the only part implemented for now in the new library. Those components are `StakeTab` and `UnstakeTab`.

This method sendTransaction:
https://github.com/telosnetwork/open-block-explorer/blob/master/src/components/resources/StakeTab.vue#L94-L132

![image](https://user-images.githubusercontent.com/4420760/225777125-d8e20a32-2203-4307-b620-7c533827fd73.png)

Now looks like this, and the best part everything updates Automatically after the action call ends.
https://github.com/telosnetwork/open-block-explorer/blob/206e58c8b49ce3f7d5d8ea8d6709781efd1c1698/src/components/resources/StakeTab.vue#L93-L116

Also the Resource summary and the Balance breakdown were updated and now includes the aggregated amount of resources delegated to other accounts.

![image](https://user-images.githubusercontent.com/4420760/225778160-279add48-0539-4eaa-8611-6480ffcd3719.png)

![image](https://user-images.githubusercontent.com/4420760/225778188-05641e4b-91a8-40ea-a99c-e84fad1bb88c.png)

## Test scenarios
Delegate to others should work and update data after success
- go to this link ([testnet](https://deploy-preview-667--obe-testnet.netlify.app/))
- log in with a non-zero TLOS balance account using a real wallet (not cleos)
- go to the wallet tab
   - You should see a new line saying "DELEGATED to others' like the screenshot
- Press the Resource button
   - In the summary, you should see 'DELEGATED TO OTHERS' with the same number
- remember your current state
   - remember the delegated to others number
   - remember your liquid TLOS (shown as available over the inputs)
- go to 'Add CPU/NET' tab
- write in the input a different account name you know
- change to a positive amount of CPU or NET
- press confirm and sign with your wallet
- If success
   - you should receive a popup showing the transfer id (close it)
   - you should see your 'DELEGATED TO OTHERS' number increased
   - you should see liquid TLOS (the available amount) being reduced

Undelegated from others should work and update the date after success.
- go to this link ([testnet](https://deploy-preview-667--obe-testnet.netlify.app/))
- log in with an account that previously had delegated some tokens to another account. Use a real wallet (not cleos)
- go to the wallet tab
   - You should see a new line saying "REFUNDING from stake' like the screenshot
- Press the Resource button
   - In the summary, you should see 'REFUNDING' with the same number
- remember your current state
   - remember the delegated to others number
   - remember the refunding amount
- go to 'Remove CPU/NET' tab
- select an account different from yours
- change to a positive amount of CPU or NET to unstake
- press confirm and sign with your wallet
- If success
   - you should receive a popup showing the transfer id (close it)
   - you should see your 'DELEGATED TO OTHERS' number reduced
   - you should see your funding amount being increased


## Checklist:
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
