### PR TITLE
520 unable to withdraw the entire rex value

### DIFF
--- a/src/components/resources/SellRam.vue
+++ b/src/components/resources/SellRam.vue
@@ -56,19 +56,6 @@ export default defineComponent({
             }
         }
 
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
-            }
-        }
-
         return {
             openTransaction,
             sellAmount,
@@ -80,7 +67,6 @@ export default defineComponent({
             sellPreview,
             formatDec,
             sell,
-            assetToAmount,
         };
     },
     computed: {

--- a/src/components/resources/StakeTab.vue
+++ b/src/components/resources/StakeTab.vue
@@ -7,6 +7,7 @@ import { getChain } from 'src/config/ConfigManager';
 import { formatCurrency, isValidAccount } from 'src/utils/string-utils';
 import { API } from '@greymass/eosio';
 import { StakeResourcesTransactionData } from 'src/types';
+import { assetToAmount } from 'src/utils/string-utils';
 
 const chain = getChain();
 const symbol = chain.getSystemToken().symbol;
@@ -45,19 +46,6 @@ export default defineComponent({
                         minimumFractionDigits: store.state.chain.token.precision,
                     })
                     .replace(/[^0-9.]/g, '');
-            }
-        }
-
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
             }
         }
 

--- a/src/components/resources/UnstakeTab.vue
+++ b/src/components/resources/UnstakeTab.vue
@@ -5,7 +5,7 @@ import { mapActions } from 'vuex';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { DelegatedResources } from 'src/store/resources/state';
-import { formatCurrency } from 'src/utils/string-utils';
+import { formatCurrency, assetToAmount } from 'src/utils/string-utils';
 
 const chain = getChain();
 const symbol = chain.getSystemToken().symbol;
@@ -42,19 +42,6 @@ export default defineComponent({
                         minimumFractionDigits: store.state.chain.token.precision,
                     })
                     .replace(/[^0-9.]/g, '');
-            }
-        }
-
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
             }
         }
 

--- a/src/components/staking/SavingsTab.vue
+++ b/src/components/staking/SavingsTab.vue
@@ -3,6 +3,7 @@ import { defineComponent, ref, computed } from 'vue';
 import { useStore } from 'src/store';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { API } from '@greymass/eosio';
+import { assetToAmount } from 'src/utils/string-utils';
 
 export default defineComponent({
     name: 'SavingsTab',
@@ -80,19 +81,6 @@ export default defineComponent({
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 openTransaction.value = true;
-            }
-        }
-
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
             }
         }
 

--- a/src/components/staking/StakingTab.vue
+++ b/src/components/staking/StakingTab.vue
@@ -4,6 +4,7 @@ import { useStore } from 'src/store';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { API } from '@greymass/eosio';
+import { assetToAmount } from 'src/utils/string-utils';
 
 const chain = getChain();
 
@@ -64,19 +65,6 @@ export default defineComponent({
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 openTransaction.value = true;
-            }
-        }
-
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
             }
         }
 

--- a/src/components/staking/UnstakingTab.vue
+++ b/src/components/staking/UnstakingTab.vue
@@ -5,6 +5,7 @@ import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { API } from '@greymass/eosio';
 import { assetToAmount } from 'src/utils/string-utils';
+import { QInput } from 'quasar';
 
 const chain = getChain();
 
@@ -18,6 +19,7 @@ export default defineComponent({
         let openTransaction = ref<boolean>(false);
         const unstakeTokens = ref<string>('');
         const symbol = ref<string>(chain.getSystemToken().symbol);
+        const unstakeInput = ref<QInput>(null);
         const transactionId = computed(
             (): string => store.state.account.TransactionId,
         );
@@ -28,6 +30,7 @@ export default defineComponent({
         const rexInfo = computed(() => store.state.account.data.rex_info);
         const rexbal = computed(() => store.state.account.rexbal);
         const maturedRex = computed(() => store.state?.account.maturedRex);
+        const maxUnlend = computed(() => assetToAmount(maturedRex.value) - .0001);
 
         function formatDec() {
             const precision = store.state.chain.token.precision;
@@ -43,13 +46,11 @@ export default defineComponent({
         }
 
         async function unstake() {
+            debugger;
             void store.dispatch('account/resetTransaction');
-            if (
-                unstakeTokens.value === '0' ||
-                !rexbal.value.vote_stake ||
-                Number(unstakeTokens.value) >=
-                Number(rexbal.value.vote_stake.split(' ')[0])
-            ) {
+            console.log(unstakeTokens.value);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+            if ((unstakeInput.value as any).hasError) {
                 return;
             }
             await store.dispatch('account/unstakeRex', {
@@ -62,13 +63,14 @@ export default defineComponent({
         }
 
         function setMaxValue() {
-            unstakeTokens.value = assetToAmount(maturedRex.value).toString();
+            unstakeTokens.value = maxUnlend.value.toString();
             void formatDec();
         }
 
         return {
             openTransaction,
             unstakeTokens,
+            unstakeInput,
             transactionId,
             transactionError,
             formatDec,
@@ -78,6 +80,7 @@ export default defineComponent({
             rexInfo,
             rexbal,
             maturedRex,
+            maxUnlend,
             symbol,
             setMaxValue,
         };
@@ -96,18 +99,19 @@ export default defineComponent({
                         <div class="col-8">{{ `MATURED ${symbol}` }}</div>
                         <div class="col-4">
                             <div class="row items-center justify-end q-hoverable cursor-pointer" @click="setMaxValue">
-                                <div class="text-weight-bold text-right balance-amount">{{maturedRex}}</div>
+                                <div class="text-weight-bold text-right balance-amount">{{ maxUnlend }} {{ symbol }}</div>
                                 <q-icon class="q-ml-xs" name="info"/>
                                 <q-tooltip>Click to fill full amount</q-tooltip>
                             </div>
                         </div>
                     </div>
                     <q-input
+                        ref="unstakeInput"
                         v-model="unstakeTokens"
                         standout="bg-deep-purple-2 text-white"
                         placeholder='0'
                         :lazy-rules='true'
-                        :rules="[ val => val >= 0  && val <= assetToAmount(maturedRex)  || 'Invalid amount.' ]"
+                        :rules="[ val => val >= 0  && val < assetToAmount(maturedRex)  || 'Invalid amount.' ]"
                         type="text"
                         dense
                         dark

--- a/src/components/staking/UnstakingTab.vue
+++ b/src/components/staking/UnstakingTab.vue
@@ -4,6 +4,7 @@ import { useStore } from 'src/store';
 import ViewTransaction from 'src/components/ViewTransanction.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { API } from '@greymass/eosio';
+import { assetToAmount } from 'src/utils/string-utils';
 
 const chain = getChain();
 
@@ -57,19 +58,6 @@ export default defineComponent({
 
             if (localStorage.getItem('autoLogin') !== 'cleos') {
                 openTransaction.value = true;
-            }
-        }
-
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
             }
         }
 

--- a/src/components/staking/UnstakingTab.vue
+++ b/src/components/staking/UnstakingTab.vue
@@ -46,9 +46,7 @@ export default defineComponent({
         }
 
         async function unstake() {
-            debugger;
             void store.dispatch('account/resetTransaction');
-            console.log(unstakeTokens.value);
             // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
             if ((unstakeInput.value as any).hasError) {
                 return;

--- a/src/components/validators/ValidatorData.vue
+++ b/src/components/validators/ValidatorData.vue
@@ -8,7 +8,7 @@ import { GetTableRowsParams } from 'src/types';
 import WalletModal from 'src/components/WalletModal.vue';
 import { getChain } from 'src/config/ConfigManager';
 import { Name } from '@greymass/eosio';
-import { formatCurrency } from 'src/utils/string-utils';
+import { formatCurrency, assetToAmount } from 'src/utils/string-utils';
 
 const chain = getChain();
 
@@ -54,18 +54,6 @@ export default defineComponent({
         const amount_voted = ref(0);
         const votesProgress = computed(() => amount_voted.value / supply.value || 0);
 
-        function assetToAmount(asset: string, decimals = -1): number {
-            try {
-                let qty: string = asset.split(' ')[0];
-                let val: number = parseFloat(qty);
-                if (decimals > -1) {
-                    qty = val.toFixed(decimals);
-                }
-                return val;
-            } catch (error) {
-                return 0;
-            }
-        }
         async function getVotingStatistics() {
             await getVoteWeight();
             await updateVoteAmount();

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -65,7 +65,6 @@ export function formatCurrency(
  * @param {string} asset - the asset value string
  */
 export function assetToAmount(asset: string): number {
-    debugger;
     try {
         const qty: string = asset.split(' ')[0];
         return parseFloat(qty);

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -59,3 +59,17 @@ export function formatCurrency(
 
     return amountAsString;
 }
+
+/**
+ * Given a string asset value (e.g. `12.3456 TLOS`), returns the numerical part as a number type.
+ * @param {string} asset - the asset value string
+ */
+export function assetToAmount(asset: string): number {
+    debugger;
+    try {
+        const qty: string = asset.split(' ')[0];
+        return parseFloat(qty);
+    } catch (error) {
+        return 0;
+    }
+}

--- a/test/jest/__tests__/utils/string-utils.spec.ts
+++ b/test/jest/__tests__/utils/string-utils.spec.ts
@@ -3,6 +3,7 @@ import {
     isValidAccount,
     isValidTransactionHex,
     formatCurrency,
+    assetToAmount,
 } from 'src/utils/string-utils';
 
 describe('string-utils utility functions', () => {
@@ -144,6 +145,14 @@ describe('string-utils utility functions', () => {
             inputs.forEach((input) => {
                 expect(() => formatCurrency(input, 2)).toThrow();
             });
+        });
+    });
+
+    describe('assetToAmount', () => {
+        it('given asset string, return numerical value as number type', () => {
+            const testAsset = '12.3456 COIN';
+            const expectedResult = 12.3456;
+            expect(assetToAmount(testAsset)).toEqual(expectedResult);
         });
     });
 });


### PR DESCRIPTION
# Fixes #520 

## Description
- adjusts max input to be less than total matured
- refactor validation for input, and assetToAmount method

## Test scenarios
Unstake Max Amount:
1. navigate to staking resources page
2. select 'unstake' tab
3. see max input amount less than total matured
4. click max input to populate, and 'unstake' for successful tx

Input Validation
1. manually enter invalid amount
2. see input validation error on input
3. 'unstake' button does nothing

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file
-   [ ] I have created a new issue with the required translations for the currently supported languages
