### PR TITLE
Fix for model not being updated on 'from' and 'to' fields.

### DIFF
--- a/src/components/AccountSearch.vue
+++ b/src/components/AccountSearch.vue
@@ -18,8 +18,8 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
-        // this prop control if we will also emmit the update event when the user is typing
-        emmitUpdateOnInput: {
+        // this prop controls if we will also emit the update event when the user is typing
+        emitUpdateOnInput: {
             type: Boolean,
             default: false,
         },
@@ -117,7 +117,7 @@ export default defineComponent({
                     });
 
                     // if has only one result and it's the one that is on the inputValue, emit update
-                    if (props.emmitUpdateOnInput) {
+                    if (props.emitUpdateOnInput) {
                         if (results.length === 2 && results[1].label === inputValue.value) {
                             isError.value = false;
                             context.emit('update:modelValue', inputValue.value);

--- a/src/components/AccountSearch.vue
+++ b/src/components/AccountSearch.vue
@@ -110,6 +110,7 @@ export default defineComponent({
                             });
                         }
                     });
+                    context.emit('update:modelValue', inputValue.value);
                 } else {
                     isError.value = true;
                 }

--- a/src/components/AccountSearch.vue
+++ b/src/components/AccountSearch.vue
@@ -110,7 +110,14 @@ export default defineComponent({
                             });
                         }
                     });
-                    context.emit('update:modelValue', inputValue.value);
+
+                    // if has only one result and it's the one that is on the inputValue, emit update
+                    if (results.length === 2 && results[1].label === inputValue.value) {
+                        isError.value = false;
+                        context.emit('update:modelValue', inputValue.value);
+                    } else {
+                        isError.value = true;
+                    }
                 } else {
                     isError.value = true;
                 }

--- a/src/components/AccountSearch.vue
+++ b/src/components/AccountSearch.vue
@@ -18,6 +18,11 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        // this prop control if we will also emmit the update event when the user is typing
+        emmitUpdateOnInput: {
+            type: Boolean,
+            default: false,
+        },
     },
     emits: ['update:modelValue', 'remove'],
     setup(props, context) {
@@ -112,11 +117,13 @@ export default defineComponent({
                     });
 
                     // if has only one result and it's the one that is on the inputValue, emit update
-                    if (results.length === 2 && results[1].label === inputValue.value) {
-                        isError.value = false;
-                        context.emit('update:modelValue', inputValue.value);
-                    } else {
-                        isError.value = true;
+                    if (props.emmitUpdateOnInput) {
+                        if (results.length === 2 && results[1].label === inputValue.value) {
+                            isError.value = false;
+                            context.emit('update:modelValue', inputValue.value);
+                        } else {
+                            isError.value = true;
+                        }
                     }
                 } else {
                     isError.value = true;

--- a/src/components/TransferAction.vue
+++ b/src/components/TransferAction.vue
@@ -97,7 +97,7 @@ export default defineComponent({
         <AccountSearch
             v-if="field.type === 'name'"
             v-model="action.data[field.name]"
-            emmitUpdateOnInput
+            emitUpdateOnInput
             outlined
             :filled="false"
             with-validation

--- a/src/components/TransferAction.vue
+++ b/src/components/TransferAction.vue
@@ -97,6 +97,7 @@ export default defineComponent({
         <AccountSearch
             v-if="field.type === 'name'"
             v-model="action.data[field.name]"
+            emmitUpdateOnInput
             outlined
             :filled="false"
             with-validation


### PR DESCRIPTION
# Fixes #680

The fields 'from' and 'to' values weren't been updated when manually typing the account name, only when clicking on an option on the list.

Updated the code to emit 'update' event when the new prop is true, the list has only one optio and the option matches the value on the input field.

## Test scenarios

Manually tested:
- Input letter by letter on the field and check if the proposal was properly created.
- Checked if filter on the transactions table wasn't affected by this change.

## Checklist:
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
