### PR TITLE
Adding permission waits

### DIFF
--- a/src/components/PermissionCard.vue
+++ b/src/components/PermissionCard.vue
@@ -78,7 +78,7 @@ export default defineComponent({
                         <div><span>{{`+${a.weight} &nbsp; &nbsp; `}}</span><span class="text-bold" v-html="formatAccount(a.permission.actor?.toString(), 'account')"></span><span> @{{a.permission.permission}}</span></div>
                     </div>
                     <div v-for="w in permissionLocal.required_auth.waits" :key="`${w.wait_sec}-${w.weight}`">
-                        <div><span>{{`+${w.weight} &nbsp; &nbsp; `}}</span><span v-html="formatWait(w.wait_sec.value)"></span></div>
+                        <div><span>{{`+${w.weight} &nbsp; &nbsp; `}}</span><span>{{ formatWait(w.wait_sec.value) }}</span></div>
                     </div>
                 </q-card-section>
                 <q-card-section v-if="permissionLocal.permission_links.length > 0" class="permission-action-section">


### PR DESCRIPTION
# Fixes #703 

## Description
This PR adds the waits for every permission

## Test scenarios
- https://e18d1166.open-block-explorer.pages.dev/account/tedp4holding?tab=keys
  - You should see the permission waits below the permission account.
![image](https://github.com/telosnetwork/open-block-explorer/assets/4420760/6f7b064a-6bb4-4bda-845f-0b4f119c853a)



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
