### PR TITLE
now we can move all to savings in rex

### DIFF
--- a/src/components/staking/SavingsTab.vue
+++ b/src/components/staking/SavingsTab.vue
@@ -53,7 +53,7 @@ export default defineComponent({
             if (
                 toSavingAmount.value === '0' ||
                 toSavingAmount.value === '' ||
-                Number(toSavingAmount.value) >= eligibleStaked.value
+                Number(toSavingAmount.value) > eligibleStaked.value
             ) {
                 return;
             }


### PR DESCRIPTION
# Fixes #734

## Description
Minor bug fix to allow the user to put all (max available) amount to savings in REX.

## Test scenarios
- go to [this link ](https://deploy-preview-735--obe-testnet.netlify.app/)and login
- go to wallet / REX / savings
- press the max-available button (displaying how much you have on top of the input field)
- press the "Move to savings" button.
  - It should work!

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
-   [x] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [x] I have tested for mobile functionality and responsiveness
-   [x] I have added appropriate test coverage 
