### PR TITLE
Fixing account not found when REX info are not available

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -140,9 +140,13 @@ export default defineComponent({
         };
 
         const loadBalances = async () => {
-            const total  = await getRexBalance();
-            rexDeposits.value = await getRexFund();
-            rexStaked.value = total;
+            try {
+                const total  = await getRexBalance();
+                rexDeposits.value = await getRexFund();
+                rexStaked.value = total;
+            } catch (e) {
+                $q.notify('REX information not available!');
+            }
         };
 
         const loadResources = () => {


### PR DESCRIPTION
# Fixes #issue_number

## Description

Fixing account not found when REX info are not available for some chains, such as Wax.

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
