### PR TITLE
Including local storage as fallback

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,6 +47,13 @@ export default route<StateInterface>(function (/* { store, ssrContext } */) {
                     path: 'network',
                     query: to.query,
                 });
+            } else if (selectedChainOnStore) { // if there is no network param and local storage has current network
+                return ({
+                    path: 'network',
+                    query: {
+                        network: selectedChainOnStore,
+                    },
+                });
             } else if (preferredChainName) { // if there is no network param and local storage has preferred network selected
                 updateSelectedChain(preferredChainName);
                 return ({
@@ -59,7 +66,15 @@ export default route<StateInterface>(function (/* { store, ssrContext } */) {
             // else, will proceed to home page
         } else {
             if (!to.query.network) { // if doesn't have network param
-                if (preferredChainName) { // if has a preferred chain selected on sotre
+                if (selectedChainOnStore) {
+                    return ({
+                        ...to,
+                        query: {
+                            ...to.query,
+                            network: selectedChainOnStore,
+                        },
+                    });
+                } else if (preferredChainName) { // if has a preferred chain selected on sotre
                     updateSelectedChain(preferredChainName);
                     return ({
                         ...to,


### PR DESCRIPTION
# Fixes #issue_number

## Description
The router wasn't taking into consideration the current chain for urls that come from the application itself, which don't have the network in the path. 

Current changes just make sure that if we have a current chain selected in the current session, we continue to use that before falling back to the preferred chain. 

Note that this would be a great candidate for a refactor, which will be addressed in future PR.
<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
