### PR TITLE
Increases row height for memo to be visible

### DIFF
--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 77; // the maximum row height
+        const maxHeight = 65; // the maximum row height
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 

--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 57; // the maximum row height
+        const maxHeight = 77; // the maximum row height
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 


### PR DESCRIPTION
# Fixes #761

## Description
Increases the row height on the transaction table so the memo is visible:

before:
<img width="1057" alt="Screenshot 2023-10-03 at 12 11 32" src="https://github.com/telosnetwork/open-block-explorer/assets/2939354/e217a6d0-8c1d-49af-86b9-06367a377cd6">

now:
<img width="1100" alt="Screenshot 2023-10-03 at 12 10 38" src="https://github.com/telosnetwork/open-block-explorer/assets/2939354/e214edd4-cd34-48e7-b560-bc0d7bc4fb81">

<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
