### PR TITLE
Fixing landing page on single chain mode

### DIFF
--- a/src/config/ConfigManager.ts
+++ b/src/config/ConfigManager.ts
@@ -18,7 +18,7 @@ export default class ConfigManager {
     }
 
     private init(): void {
-        const showMultichainSelector = process.env.SHOW_MULTICHAIN_SELECTOR;
+        const showMultichainSelector = process.env.SHOW_MULTICHAIN_SELECTOR === 'true';
         const configuredChain = process.env.CHAIN_NAME;
         this.testnets = chainsConfig.testnets;
         this.mainnets = chainsConfig.mainnets;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,80 +40,83 @@ export default route<StateInterface>(function (/* { store, ssrContext } */) {
         const chains = configMgr.getAllChains();
         const selectedChainOnStore = sessionStorage.getItem(ConfigManager.CHAIN_LOCAL_STORAGE);
         const preferredChainName = configMgr.getPreferredChain();
+        const isMultichain = process.env.SHOW_MULTICHAIN_SELECTOR === 'true';
 
-        if (to.path === '/') { // if attempting to go to home page
-            if (process.env.SHOW_MULTICHAIN_SELECTOR !== 'true') {
-                return({
-                    path: 'network',
-                    query: {
-                        network: process.env.CHAIN_NAME,
-                    },
-                });
-            }
-            if (to.query.network) { // if there is network param, proceed to network with the param
-                return ({
-                    path: 'network',
-                    query: to.query,
-                });
-            } else if (selectedChainOnStore) { // if there is no network param and local storage has current network
-                return ({
-                    path: 'network',
-                    query: {
-                        network: selectedChainOnStore,
-                    },
-                });
-            } else if (preferredChainName) { // if there is no network param and local storage has preferred network selected
-                updateSelectedChain(preferredChainName);
-                return ({
-                    path: 'network',
-                    query: {
-                        network: preferredChainName,
-                    },
-                });
-            }
-            // else, will proceed to home page
-        } else {
-            if (!to.query.network) { // if doesn't have network param
-                if (selectedChainOnStore) {
-                    return ({
-                        ...to,
+        if(isMultichain) {
+            if (to.path === '/') { // if attempting to go to home page
+                if (process.env.SHOW_MULTICHAIN_SELECTOR !== 'true') {
+                    return({
+                        path: 'network',
                         query: {
-                            ...to.query,
+                            network: process.env.CHAIN_NAME,
+                        },
+                    });
+                }
+                if (to.query.network) { // if there is network param, proceed to network with the param
+                    return ({
+                        path: 'network',
+                        query: to.query,
+                    });
+                } else if (selectedChainOnStore) { // if there is no network param and local storage has current network
+                    return ({
+                        path: 'network',
+                        query: {
                             network: selectedChainOnStore,
                         },
                     });
-                } else if (preferredChainName) { // if has a preferred chain selected on sotre
+                } else if (preferredChainName) { // if there is no network param and local storage has preferred network selected
                     updateSelectedChain(preferredChainName);
                     return ({
-                        ...to,
+                        path: 'network',
                         query: {
-                            ...to.query,
                             network: preferredChainName,
                         },
                     });
-                } else { // if doesn't have a preferred chain selected on store, go to home page (landing page)
-                    return ({
-                        path: '/',
-                    });
                 }
-            } else if (chains.filter(chain => chain.getName() === to.query.network).length === 0) { // check if the network is not part of the system
-                if (preferredChainName) { // if has a preferred chain selected on sotre
-                    updateSelectedChain(preferredChainName);
-                    return ({
-                        ...to,
-                        query: {
-                            ...to.query,
-                            network: preferredChainName,
-                        },
-                    });
-                } else { // if doesn't have a preferred chain selected on store, go to home page (landing page)
-                    return ({
-                        path: '/',
-                    });
+                // else, will proceed to home page
+            } else {
+                if (!to.query.network) { // if doesn't have network param
+                    if (selectedChainOnStore) {
+                        return ({
+                            ...to,
+                            query: {
+                                ...to.query,
+                                network: selectedChainOnStore,
+                            },
+                        });
+                    } else if (preferredChainName) { // if has a preferred chain selected on sotre
+                        updateSelectedChain(preferredChainName);
+                        return ({
+                            ...to,
+                            query: {
+                                ...to.query,
+                                network: preferredChainName,
+                            },
+                        });
+                    } else { // if doesn't have a preferred chain selected on store, go to home page (landing page)
+                        return ({
+                            path: '/',
+                        });
+                    }
+                } else if (chains.filter(chain => chain.getName() === to.query.network).length === 0) { // check if the network is not part of the system
+                    if (preferredChainName) { // if has a preferred chain selected on sotre
+                        updateSelectedChain(preferredChainName);
+                        return ({
+                            ...to,
+                            query: {
+                                ...to.query,
+                                network: preferredChainName,
+                            },
+                        });
+                    } else { // if doesn't have a preferred chain selected on store, go to home page (landing page)
+                        return ({
+                            path: '/',
+                        });
+                    }
+                } else if ((from.query.network && from.query.network !== to.query.network) || selectedChainOnStore !== to.query.network) { // if i'm changing from network
+                    updateSelectedChain(Array.isArray(to.query.network) ? to.query.network[0] : to.query.network);
+                    setTimeout(() => location.reload(), 500);
                 }
-            } else if ((from.query.network && from.query.network !== to.query.network) || selectedChainOnStore !== to.query.network) { // if i'm changing from network
-                updateSelectedChain(Array.isArray(to.query.network) ? to.query.network[0] : to.query.network);
-                setTimeout(() => location.reload(), 500);
             }
         }
     });

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -44,14 +44,6 @@ export default route<StateInterface>(function (/* { store, ssrContext } */) {
 
         if(isMultichain) {
             if (to.path === '/') { // if attempting to go to home page
-                if (process.env.SHOW_MULTICHAIN_SELECTOR !== 'true') {
-                    return({
-                        path: 'network',
-                        query: {
-                            network: process.env.CHAIN_NAME,
-                        },
-                    });
-                }
                 if (to.query.network) { // if there is network param, proceed to network with the param
                     return ({
                         path: 'network',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -42,6 +42,14 @@ export default route<StateInterface>(function (/* { store, ssrContext } */) {
         const preferredChainName = configMgr.getPreferredChain();
 
         if (to.path === '/') { // if attempting to go to home page
+            if (process.env.SHOW_MULTICHAIN_SELECTOR !== 'true') {
+                return({
+                    path: 'network',
+                    query: {
+                        network: process.env.CHAIN_NAME,
+                    },
+                });
+            }
             if (to.query.network) { // if there is network param, proceed to network with the param
                 return ({
                     path: 'network',

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -1,10 +1,19 @@
 import { RouteRecordRaw } from 'vue-router';
 
+const isMultichain = process.env.SHOW_MULTICHAIN_SELECTOR === 'true';
+
 const routes: RouteRecordRaw[] = [
     {
         path: '/',
         name: 'home',
         component: () => import('pages/Home.vue'),
+        beforeEnter:(to, from, next) => {
+            if (!isMultichain) {
+                next('/network');
+            } else {
+                next();
+            }
+        },
     },
     {
         path: '/account/:account',


### PR DESCRIPTION
# Fixes #766 #767 

## Description

Disabling landing page on single-chain mode.
Includes fix for validation of `SHOW_MULTICHAIN_SELECTOR` that is a `string` and was being considered a `boolean`.

## Test scenarios
- Make sure `SHOW_MULTICHAIN_SELECTOR` is `false`
- Make sure you have `CHAIN_NAME` set to the desired network
- Navigate through the website without ever seeing the home page

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
