### PR TITLE
Fix misspelling of 'Disconnect'

### DIFF
--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -65,7 +65,7 @@ export default defineComponent({
                 <q-btn
                     class="full-width"
                     color="primary"
-                    label="Disconect"
+                    label="Disconnect"
                     @click="onLogout"
                 />
             </div>


### PR DESCRIPTION
# Fixes #770

## Description

Simple text string fix of misspelling

## Test scenarios

Boot app, log in , and check 'Disconnect' button is spelled correctly.

## Checklist:
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
