### PR TITLE
Increase tx payload height to 3 lines (instead of 2)

### DIFF
--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 98; // the maximum row height, should this be scalar (3) * constant (line height)?
+        const maxHeight = 98; // the maximum row height
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 

--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 65; // the maximum row height
+        const maxHeight = 98; // the maximum row height, should this be scalar (3) * constant (line height)?
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 


### PR DESCRIPTION
# Fixes #750 

## Description

Adjusted height before "expand button" for tx payload to approximately three lines instead of 2.

## Test scenarios

Went to page, checked how many lines show the "expand" button vs does not show it.

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/cfdbf540-a34f-4b0c-a98b-50b26d62151d)

