### PR TITLE
Hide tx data overflow and allow line-wrap

### DIFF
--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 98; // the maximum row height
+        const maxHeight = 130; // the maximum row height
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 
@@ -108,10 +108,10 @@ export default defineComponent({
 
 <template>
 <div
-    class="relative-position"
+    class="relative-position overflow-hidden"
     :class="{'div-compressed': !showOverflow}"
 >
-    <div v-if="actionName === 'transfer'" ref="dataBox" class="row">
+    <div v-if="actionName === 'transfer'" ref="dataBox" class="row transfer-data">
         <div class="col-12">
             <span class="text-bold">
                 <AccountFormat :account="transferData.from" type="account"/></span><span class="text-bold">&nbsp; → &nbsp;
@@ -156,6 +156,9 @@ export default defineComponent({
   flex-direction: column
   gap: 5px
   word-break: break-all
+
+.transfer-data
+  text-wrap: wrap
 
 .div-compressed
     max-height: v-bind(maxHeightStyle)


### PR DESCRIPTION
# Fixes #779 

## Description

Styling adjustments for tx payload data that is either a.) too long for one line or b.) goes vertically past the "expand" icon (downward chevron / arrow)

## Test scenarios

Checked on both desktop and mobile

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/b1f1004e-9e23-433c-b6cf-65bf3b41f6bc)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
