### PR TITLE
Adjust account statistics font color

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -680,7 +680,7 @@ $medium:750px
 
   .q-table__card
     background: unset
-    color: rgba(255, 255, 255, 0.5)
+    color: rgba(255, 255, 255, 0.8)
 
   .q-table--horizontal-separator
     thead th


### PR DESCRIPTION
# Fixes #780 

## Description

Adjusted the opacity from 0.5 to 0.8 for the account statistics area. I still think the readability is mediocre but that's a different discussion.

## Test scenarios

Tested in desktop browser. Mobile should not be any different.

Before:
![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/d6540691-91f2-4f8f-bbad-99537ae297eb)
After:
![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/ea816fb1-fb4e-49a5-ab8f-2b3e6dc3335a)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
