### PR TITLE
Add decimal place for any token under 1 USD

### DIFF
--- a/src/components/PriceChart.vue
+++ b/src/components/PriceChart.vue
@@ -101,7 +101,7 @@ export default defineComponent({
             chartOptions.value.series[0].data = data.prices;
         };
         const formatPercentage = (val: number): string => `${val.toFixed(2)} %`;
-        const formatCurrencyValue = (val: number): string => val < ONE_MILLION
+        const formatCurrencyValue = (val: number): string => val < 1 ? `$${val.toFixed(3)}` : val < ONE_MILLION
             ? `$${val.toFixed(2)}`
             : val < ONE_BILLION
                 ? `$${(val / ONE_MILLION).toFixed(2)}M`


### PR DESCRIPTION
# Fixes #784 

## Description

It checks the price and if it is under 1 USD then it adds an extra decimal (3 instead of 2). Relevant for current TLOS price.

## Test scenarios

Checked on desktop and mobile

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/2f1b5181-dd51-4b81-9bea-e616a13f60e9)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
