### PR TITLE
Add 'Z' to tx timestamps to tell client that it's UTC

### DIFF
--- a/src/components/transaction/TransactionCard.vue
+++ b/src/components/transaction/TransactionCard.vue
@@ -107,7 +107,7 @@ export default defineComponent({
                         <div class="col-xs-12 col-sm-6">
                             <div class="text-body1 text-weight-medium text-uppercase">Block time</div>
                         </div>
-                        <div class="col-xs-12 col-sm-6 text-right text-bold">{{formatDate(timestamp)}}</div>
+                        <div class="col-xs-12 col-sm-6 text-right text-bold">{{formatDate(`${timestamp}Z`)}}</div>
                     </div>
                 </q-card-section>
                 <q-separator class="card-separator" inset="inset"/>


### PR DESCRIPTION
# Fixes #707 

## Description

- TX timestamp showing incorrect because block timestamps do not have the 'Z' indicating the UTC time zone. They are not ISO-compliant 👎 but since they always do not have the 'Z' then we can just manually add it

## Test scenarios

Time now matches the timestamp on the homepage

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
