### PR TITLE
Adjust Account dropdown text and background on hover

### DIFF
--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -59,7 +59,7 @@ export default defineComponent({
             <a class="text-white" :href=" '/account/' + account">
                 <div class="row">
                     <div class="col-12">
-                        Account
+                        View my account
                     </div>
                 </div>
             </a>

--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -55,10 +55,14 @@ export default defineComponent({
     :content-style="{ backgroundColor: '#172c6c' }"
 >
     <q-card class="buttons-container">
-        <q-card-section>
-            <div class="row">
-                <div class="col-12"><a class="text-white hover-dec" :href=" '/account/' + account">{{account}}</a></div>
-            </div>
+        <q-card-section class="account-link">
+            <a class="text-white" :href=" '/account/' + account">
+                <div class="row">
+                    <div class="col-12">
+                        Account
+                    </div>
+                </div>
+            </a>
         </q-card-section>
         <q-separator dark/>
         <q-card-section>
@@ -89,6 +93,14 @@ export default defineComponent({
   width: fit-content
   height: 40px
   text-transform: lowercase
+
+.account-link
+  &:hover
+    cursor: pointer
+    transition: background-color .3s
+    background-color: color-mix(in oklab, var(--q-secondary) 88%, white 12%)
+  a
+    text-decoration: none
 .buttons-container
   width: 220px
   max-width: 80vw

--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -103,7 +103,7 @@ export default defineComponent({
     text-decoration: none
     div
         width: fit-content
-        margin-left: .5rem
+        margin-left: .25rem
 .buttons-container
   width: 220px
   max-width: 80vw

--- a/src/components/LoginHandlerDropdown.vue
+++ b/src/components/LoginHandlerDropdown.vue
@@ -101,6 +101,9 @@ export default defineComponent({
     background-color: color-mix(in oklab, var(--q-secondary) 88%, white 12%)
   a
     text-decoration: none
+    div
+        width: fit-content
+        margin-left: .5rem
 .buttons-container
   width: 220px
   max-width: 80vw


### PR DESCRIPTION
# Fixes #473 

## Description

Changed the account dropdown from displaying the account name (again) to "Account". Also added some hover effects.

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/92abb9df-6ce7-4fa5-87b6-77f47d57c0ad)


## Test scenarios

Checked on both desktop and mobile

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
