### PR TITLE
Add comma separators for block numbers on homepage

### DIFF
--- a/src/components/MapData.vue
+++ b/src/components/MapData.vue
@@ -34,7 +34,7 @@ export default defineComponent({
     <div class="col-3">
         <div class="row">
             <div class="col-12 text-subtitle1 text-weight-thin text-uppercase">Head Block</div>
-            <div class="col-12 text-subtitle1 text-bold">{{HeadBlock}}</div>
+            <div class="col-12 text-subtitle1 text-bold">{{HeadBlock.toLocaleString()}}</div>
         </div>
     </div>
     <div class="col-1">
@@ -52,7 +52,7 @@ export default defineComponent({
     <div class="col-3">
         <div class="row">
             <div class="col-12 text-subtitle1 text-weight-thin text-uppercase">Irreversible Block</div>
-            <div class="col-12 text-subtitle1 text-bold">{{lastIrreversibleBlock}}</div>
+            <div class="col-12 text-subtitle1 text-bold">{{lastIrreversibleBlock.toLocaleString()}}</div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
# Fixes #794 

## Description

Just added a couple of `.toLocaleString()` to the numbers

## Test scenarios

Just go to homepage and check it yourself.

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/a238b51e-44dc-42ce-95b7-c2057a976644)


## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage 
