### PR TITLE
Add BP Votes Tab to Account Page

### DIFF
--- a/src/components/BpVotes.vue
+++ b/src/components/BpVotes.vue
@@ -1,0 +1,119 @@
+<script>
+import { getHyperionAccountData } from 'src/api/hyperion';
+
+export default {
+    props: {
+        account: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            bpVotes: [],
+        };
+    },
+    async mounted() {
+        const {
+            account: {
+                voter_info: { producers },
+            },
+        } = await getHyperionAccountData(this.account);
+        this.bpVotes = producers;
+    },
+};
+</script>
+
+<template>
+<div
+    class="row col-12 q-my-xs justify-center text-left container-max-width"
+>
+    <div class="row col-11">
+        <div class="row col-12 q-mt-lg">
+            <div>
+                <p class="panel-title">Votes for Block Producers</p>
+            </div>
+            <q-space />
+        </div>
+        <q-separator class="row col-12 q-mt-md separator" />
+        <div class="info-wrap">
+            <div class="row voted-producers q-pa-md">
+                <p>Currently voting for the {{ bpVotes.length }} out of 30 possible block producers:</p>
+                <div v-if="bpVotes.length" class="producers-list">
+                    <span
+                        v-for="producer in bpVotes"
+                        v-bind:key="producer"
+                        class="producer-name"
+                    >
+                        <a :href="`/account/${producer}`">{{ producer }}</a>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</template>
+
+<style lang="scss">
+.info-wrap {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+
+    @media (min-width: $breakpoint-sm-min) {
+        flex-direction: row-reverse;
+        align-items: flex-start;
+    }
+
+    .vote-fraction-wrap {
+        // color: var(--q-primary);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+
+        .bp-vote-circle {
+            color: var(--q-primary);
+        }
+
+        @media (min-width: $breakpoint-sm-min) {
+            border-left: 1px solid var(--q-color-seperator-background);
+        }
+    }
+
+    .voted-producers {
+        display: block;
+        width: 100%;
+
+        p {
+            margin-bottom: 20px;
+            width: 100%;
+            display: none;
+
+            @media (min-width: $breakpoint-sm-min) {
+                display: block;
+            }
+        }
+
+        .producers-list {
+            width: 100%;
+            /* make grid with column width 100px and 20px margin */
+            display: inline-grid;
+            grid-template-columns: repeat(auto-fill, 100px);
+            grid-gap: 20px;
+
+            .producer-name {
+                width: 100px;
+                margin-right: 20px;
+
+                a {
+                    text-decoration: none;
+                    color: var(--q-primary);
+                }
+            }
+        }
+    }
+}
+</style>

--- a/src/components/BpVotes.vue
+++ b/src/components/BpVotes.vue
@@ -1,27 +1,27 @@
-<script>
+<script setup lang="ts">
+import { ref, defineProps, onMounted } from 'vue';
 import { getHyperionAccountData } from 'src/api/hyperion';
 
-export default {
-    props: {
-        account: {
-            type: String,
-            required: true,
-        },
+const  props = defineProps({
+    account: {
+        type: String,
+        required: true,
     },
-    data() {
-        return {
-            bpVotes: [],
-        };
-    },
-    async mounted() {
+});
+
+const bpVotes = ref([]);
+onMounted(async () => {
+    try {
         const {
             account: {
                 voter_info: { producers },
             },
-        } = await getHyperionAccountData(this.account);
-        this.bpVotes = producers;
-    },
-};
+        } = await getHyperionAccountData(props.account);
+        bpVotes.value = producers;
+    } catch(e) {
+        console.error(e);
+    }
+});
 </script>
 
 <template>
@@ -68,7 +68,6 @@ export default {
     }
 
     .vote-fraction-wrap {
-        // color: var(--q-primary);
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/pages/Account.vue
+++ b/src/pages/Account.vue
@@ -6,6 +6,7 @@ import KeysPanel from 'components/KeysPanel.vue';
 import ChildrenPanel from 'components/ChildrenPanel.vue';
 import AccountCard from 'components/AccountCard.vue';
 import ContractTabs from 'components/contract/ContractTabs.vue';
+import BpVotes from 'components/BpVotes.vue';
 import { api } from 'src/api';
 import { useRoute, useRouter } from 'vue-router';
 import { useStore } from 'src/store';
@@ -20,6 +21,7 @@ export default defineComponent({
         ChildrenPanel,
         AccountCard,
         ContractTabs,
+        BpVotes,
     },
     setup() {
         const store = useStore();
@@ -67,6 +69,7 @@ export default defineComponent({
             <q-tab v-if="!accountPageSettings.hideContractsTab && abi" name="contract" label="Contract"/>
             <q-tab v-if="!accountPageSettings.hideTokensTab" name="tokens" label="Tokens"/>
             <q-tab v-if="!accountPageSettings.hideKeysTab" name="keys" label="Keys"/>
+            <q-tab name="votes" label="Votes"/>
             <q-tab v-if="!accountPageSettings.hideChildrenTab" name="children" label="Children"/>
         </q-tabs>
     </div>
@@ -82,6 +85,9 @@ export default defineComponent({
         </q-tab-panel>
         <q-tab-panel v-if="!accountPageSettings.hideKeysTab" name="keys">
             <KeysPanel :account="account"/>
+        </q-tab-panel>
+        <q-tab-panel name="votes">
+            <BpVotes :account="account"/>
         </q-tab-panel>
         <q-tab-panel v-if="!accountPageSettings.hideChildrenTab" name="children">
             <ChildrenPanel :account="account"/>


### PR DESCRIPTION
# Fixes #751 

## Description

Add a tab on the Account page that shows the BPs that the user has voted for.

## Test scenarios

Go to account page and click on "Votes" tab.

https://github.com/telosnetwork/open-block-explorer/assets/6249205/e93ffc06-3698-46ed-996c-7c22a334795b



## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [X] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] I have cleaned up the code in the areas my change touches
-   [X] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [X] I have checked my code and corrected any misspellings
-   [X] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [X] I have tested for mobile functionality and responsiveness
-   [X] I have added appropriate test coverage 
