### PR TITLE
Move exact search matches to top of dropdown

### DIFF
--- a/src/components/HeaderSearch.vue
+++ b/src/components/HeaderSearch.vue
@@ -57,9 +57,10 @@ export default defineComponent({
                     } as TableByScope]);
                 }
 
+                let label = 'Accounts';
                 if (accounts.length > 0) {
                     results.push({
-                        label: 'Accounts',
+                        label: label,
                         to: '',
                         isHeader: true,
                     });
@@ -71,6 +72,18 @@ export default defineComponent({
                                 to: `/account/${user.payer}`,
                                 isHeader: false,
                             });
+                        }
+                    });
+                    type Result = { label: string, to: string, isHeader: boolean }
+                    results.sort((a: Result, b: Result) => {
+                        if (a.label === label) {
+                            return -1;
+                        }
+                        if (a.label === value) {
+                            if (b.label === label) {
+                                return 1;
+                            }
+                            return -1;
                         }
                     });
                 }


### PR DESCRIPTION
# Fixes #816

## Description

For accounts, exact matches are prioritized at the top of the search results.

## Test scenarios

1. Search `eosio`
2. See if it shows up above `eosio.null` and `eosio.evm`, etc

## Checklist:

![image](https://github.com/telosnetwork/open-block-explorer/assets/6249205/06123429-5434-4cec-9f6b-dcab5f6ae69f)

