### PR TITLE
fix: allow any user to execute an approved proposal

### DIFF
--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -281,7 +281,7 @@ export default defineComponent({
 
             proposer.value = proposal.proposer;
 
-            const totalRequestedApprovals = proposal.provided_approvals.length + proposal.requested_approvals.length
+            const totalRequestedApprovals = proposal.provided_approvals.length + proposal.requested_approvals.length;
             isApproved.value = proposal.provided_approvals.length === totalRequestedApprovals;
             approvalStatus.value = `${proposal.provided_approvals.length}/${totalRequestedApprovals}`;
             isExecuted.value = proposal.executed;

--- a/src/pages/ProposalItem.vue
+++ b/src/pages/ProposalItem.vue
@@ -36,6 +36,7 @@ export default defineComponent({
         const isExecuted = ref(false);
         const isCanceled = ref(false);
         const isUserApprovalList = ref(false);
+        const isApproved = ref(false);
 
         const multsigTransactionData = ref<Action[]>([]);
         const requestedApprovalsRows = ref<RequestedApprovals[]>([]);
@@ -85,9 +86,7 @@ export default defineComponent({
         const isShowExecuteButton = computed(() => (
             isAuthenticated.value &&
             !hasProposalAlreadyExpired.value &&
-            (account.value === proposer.value ||
-                isUserApprovalList.value ||
-                hasUserAlreadyApproved.value) &&
+            isApproved.value &&
             !isExecuted.value &&
             !isCanceled.value
         ));
@@ -281,10 +280,12 @@ export default defineComponent({
             }
 
             proposer.value = proposal.proposer;
-            approvalStatus.value = `${proposal.provided_approvals.length}/${
-                proposal.provided_approvals.length + proposal.requested_approvals.length
-            }`;
+
+            const totalRequestedApprovals = proposal.provided_approvals.length + proposal.requested_approvals.length
+            isApproved.value = proposal.provided_approvals.length === totalRequestedApprovals;
+            approvalStatus.value = `${proposal.provided_approvals.length}/${totalRequestedApprovals}`;
             isExecuted.value = proposal.executed;
+
             hasUserAlreadyApproved.value = proposal.provided_approvals.some(
                 item => item.actor === account.value,
             );


### PR DESCRIPTION
## Description
Allow any user to execute an approved proposal

## Test scenarios
Execute an approved proposal with an account that was not required to approve

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [x] My changes generate no new warnings
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] I have removed any unnecessary console messages
