### PR TITLE
#839 | adding fathom analytics

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -30,7 +30,7 @@ module.exports = configure(function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/boot-files
-    boot: ['config', 'axios', 'api', 'ual', 'fuel'],
+    boot: ['config', 'axios', 'fathom', 'api', 'ual', 'fuel'],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ['app.sass'],

--- a/src/boot/fathom.ts
+++ b/src/boot/fathom.ts
@@ -1,0 +1,19 @@
+import { boot } from 'quasar/wrappers';
+import { getChain } from 'src/config/ConfigManager';
+
+declare const fathom: { trackEvent: (eventName: string) => void };
+
+export default boot(({ app }) => {
+    const siteID = getChain().getFathomSiteId();
+    if (siteID) {
+        const script = document.createElement('script');
+        script.src = 'https://cdn.usefathom.com/script.js';
+        script.dataset.site = siteID;
+        script.dataset.spa = 'auto';
+        script.defer = true;
+        script.onload = () => {
+            app.config.globalProperties.$fathom = fathom;
+        };
+        document.body.appendChild(script);
+    }
+});

--- a/src/config/BaseChain.ts
+++ b/src/config/BaseChain.ts
@@ -63,45 +63,46 @@ export const baseUiConfiguration: UiCustomization = {
 };
 
 export default abstract class BaseChain implements Chain {
-  protected name: string;
+    protected name: string;
 
-  constructor(name: string) {
-      this.name = name;
-  }
+    constructor(name: string) {
+        this.name = name;
+    }
 
-  getName(): string {
-      return this.name;
-  }
+    getName(): string {
+        return this.name;
+    }
 
-  getLargeLogoPath(): string {
-      return `~/assets/${this.name}/logo_lg.svg`;
-  }
+    getLargeLogoPath(): string {
+        return `~/assets/${this.name}/logo_lg.svg`;
+    }
 
-  getSmallLogoPath(): string {
-      return `~/assets/${this.name}/logo_sm.svg`;
-  }
+    getSmallLogoPath(): string {
+        return `~/assets/${this.name}/logo_sm.svg`;
+    }
 
-  abstract getSystemToken(): Token;
-  abstract getChainId(): string;
-  abstract getDisplay(): string;
-  abstract getHyperionEndpoint(): string;
-  abstract getRPCEndpoint(): RpcEndpoint;
-  abstract getFuelRPCEndpoint(): RpcEndpoint | null;
-  abstract getApiEndpoint(): string;
-  abstract getS3ProducerBucket(): string;
-  abstract getPriceData(): Promise<PriceChartData>;
-  abstract getUsdPrice(): Promise<number>;
-  abstract getMapDisplay(): boolean;
-  abstract getTheme(): Theme;
-  abstract getFooterLinks(): FooterLink[];
+    abstract getSystemToken(): Token;
+    abstract getChainId(): string;
+    abstract getDisplay(): string;
+    abstract getHyperionEndpoint(): string;
+    abstract getRPCEndpoint(): RpcEndpoint;
+    abstract getFuelRPCEndpoint(): RpcEndpoint | null;
+    abstract getApiEndpoint(): string;
+    abstract getS3ProducerBucket(): string;
+    abstract getPriceData(): Promise<PriceChartData>;
+    abstract getUsdPrice(): Promise<number>;
+    abstract getMapDisplay(): boolean;
+    abstract getTheme(): Theme;
+    abstract getFooterLinks(): FooterLink[];
+    abstract getFathomSiteId(): string | null;
 
-  getUiCustomization(): UiCustomization {
-      return baseUiConfiguration;
-  }
+    getUiCustomization(): UiCustomization {
+        return baseUiConfiguration;
+    }
 
-  abstract getFiltersSupported(prop: string): boolean;
+    abstract getFiltersSupported(prop: string): boolean;
 
-  isTestnet(): boolean {
-      return false;
-  }
+    isTestnet(): boolean {
+        return false;
+    }
 }

--- a/src/config/chains/eos/index.ts
+++ b/src/config/chains/eos/index.ts
@@ -133,4 +133,8 @@ export default class EOS extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return null;
+    }
 }

--- a/src/config/chains/jungle/index.ts
+++ b/src/config/chains/jungle/index.ts
@@ -145,4 +145,9 @@ export default class TelosTestnet extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return null;
+    }
+
 }

--- a/src/config/chains/telos-testnet/index.ts
+++ b/src/config/chains/telos-testnet/index.ts
@@ -147,4 +147,9 @@ export default class TelosTestnet extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return 'HKAXCRJB';
+    }
+
 }

--- a/src/config/chains/telos/index.ts
+++ b/src/config/chains/telos/index.ts
@@ -150,4 +150,9 @@ export default class Telos extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return 'VMVLEWFD';
+    }
+
 }

--- a/src/config/chains/ux/index.ts
+++ b/src/config/chains/ux/index.ts
@@ -102,4 +102,9 @@ export default class UX extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return null;
+    }
+
 }

--- a/src/config/chains/wax/index.ts
+++ b/src/config/chains/wax/index.ts
@@ -105,4 +105,9 @@ export default class EOS extends BaseChain {
             { label: 'REPOSITORY', url: 'https://github.com/telosnetwork/open-block-explorer' },
         ];
     }
+
+    getFathomSiteId(): string | null {
+        return null;
+    }
+
 }

--- a/src/types/Chain.d.ts
+++ b/src/types/Chain.d.ts
@@ -24,4 +24,5 @@ export interface Chain {
   getFiltersSupported(prop: string): boolean;
   isTestnet(): boolean;
   getFooterLinks(): FooterLink[];
+  getFathomSiteId(): string | null;
 }


### PR DESCRIPTION
# Fixes #839

## Description
This PR adds the Fathom analytics library to track traffic without specific events. Each chain may or may not have a SiteId already set to be used for the library.

