### PR TITLE
Updates WAX precision

### DIFF
--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -82,9 +82,9 @@ export default defineComponent({
         const resetForm = () => {
             sendToken.value = {
                 symbol: chain.getSystemToken().symbol,
-                precision: 4,
-                amount: 0,
-                contract: 'eosio.token',
+                precision: chain.getSystemToken().precision,
+                amount: chain.getSystemToken().amount,
+                contract: chain.getSystemToken().contract,
             };
         };
 

--- a/src/config/chains/wax/index.ts
+++ b/src/config/chains/wax/index.ts
@@ -15,7 +15,7 @@ const NAME = 'wax';
 const DISPLAY = 'WAX';
 const TOKEN = {
     symbol: 'WAX',
-    precision: 4,
+    precision: 8,
     amount: 0,
     contract: 'eosio.token',
 } as Token;


### PR DESCRIPTION
## Description
Updates WAX's precision from 4 to 8 so users don't have to manually change it. It also removes the one instance found that used a hardcoded precision and not the one defined within the chain configuration file.

<!---
Include a summary of your change and how it solves the issue its related to
-->

## Test scenarios

<!---
Describe the test scenarios that you ran to verify your changes.
Include any relevant configuration to required to reproduce them.
-->

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [ ] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage
-   [ ] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
