### PR TITLE
Paginate by action

### DIFF
--- a/src/components/BlockCard.vue
+++ b/src/components/BlockCard.vue
@@ -15,6 +15,10 @@ import { formatDate } from 'src/utils/string-utils';
 export default defineComponent({
     name: 'BlockCard',
     props: {
+        block_num: {
+            type: String,
+            required: true,
+        },
         block: {
             type: Object as PropType<Block>,
             required: false,
@@ -22,8 +26,10 @@ export default defineComponent({
         },
     },
     setup(props) {
+        const loading = ref<boolean>(true);
         const router = useRouter();
         const q = useQuasar();
+        const blockNum = computed(() => props.block_num);
         const Block = computed(() => props.block);
         const blockInfo = ref<{ key: string; value: string }[]>([]);
         async function nextBlock() {
@@ -96,6 +102,7 @@ export default defineComponent({
                     },
                     { key: 'Actions', value: actionCount.toString() },
                 ];
+                loading.value = false;
             }
         }
         watch(Block, () => {
@@ -105,13 +112,14 @@ export default defineComponent({
             setBlockData();
         });
         return {
-            block_num: computed(() => Block.value?.block_num || 0),
             nextBlock,
             previousBlock,
             numberWithCommas,
             formatDate,
             copy,
             blockInfo,
+            blockNum,
+            loading,
         };
     },
 });
@@ -154,7 +162,7 @@ export default defineComponent({
                 </q-card-section>
                 <q-card-section class="q-pt-none">
                     <div class="row items-center">
-                        <div class="col-11 text-bold ellipsis">{{numberWithCommas(block_num)}}</div>
+                        <div class="col-11 text-bold ellipsis">{{numberWithCommas(parseInt(block_num))}}</div>
                         <div class="col-1">
                             <q-btn
                                 class="float-right"
@@ -168,20 +176,28 @@ export default defineComponent({
                         </div>
                     </div>
                 </q-card-section>
-                <q-card-section>
-                    <div class="text-grey-7">SUMMARY</div>
+                <!-- we show a centered spinner if loading is true -->
+                <q-card-section v-if="loading" class="q-pa-none">
+                    <div class="row full-width justify-center">
+                        <q-spinner-dots color="primary" size="40px"/>
+                    </div>
                 </q-card-section>
-                <div v-for="item in blockInfo" :key="item.key">
-                    <q-separator class="card-separator" inset="inset"/>
+                <template v-else>
                     <q-card-section>
-                        <div class="row">
-                            <div class="col-xs-12 col-sm-6">
-                                <div class="text-body1 text-weight-medium text-uppercase">{{item.key}}</div>
-                            </div>
-                            <div class="col-xs-12 col-sm-6 text-right text-bold">{{item.value}}</div>
-                        </div>
+                        <div class="text-grey-7">SUMMARY</div>
                     </q-card-section>
-                </div>
+                    <div v-for="item in blockInfo" :key="item.key">
+                        <q-separator class="card-separator" inset="inset"/>
+                        <q-card-section>
+                            <div class="row">
+                                <div class="col-xs-12 col-sm-6">
+                                    <div class="text-body1 text-weight-medium text-uppercase">{{item.key}}</div>
+                                </div>
+                                <div class="col-xs-12 col-sm-6 text-right text-bold">{{item.value}}</div>
+                            </div>
+                        </q-card-section>
+                    </div>
+                </template>
             </div>
         </q-card>
     </div>

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -251,9 +251,8 @@ export default defineComponent({
         const filterRows = () => {
             filteredRows.value = rows.value;
         };
-
         const loadTableData = async (): Promise<void> => {
-            let tableData: Action[];
+            let tableData: Action[] = [];
             if (isTransaction.value) {
                 tableData = (await api.getTransaction(account.value)).actions;
             } else if (hasActions.value) {
@@ -261,46 +260,21 @@ export default defineComponent({
             } else {
                 const page = paginationSettings.value.page;
                 let limit = paginationSettings.value.rowsPerPage;
-
-                let notified = accountsModel.value ?? '';
-                let after = '';
-                let before = '';
-                if (toDateModel.value !== now) {
-                    before = new Date(toDateModel.value).toISOString();
-                }
-                if (fromDateModel.value !== '') {
-                    after = new Date(fromDateModel.value).toISOString();
-                }
+                const notified = accountsModel.value ?? '';
+                const after = fromDateModel.value !== '' ? new Date(fromDateModel.value).toISOString() : '';
+                const before = toDateModel.value !== now ? new Date(toDateModel.value).toISOString() : '';
                 const sort = paginationSettings.value.descending ? 'desc' : 'asc';
+                const extras: {[key:string]:string} = {};
 
-                let extras: {[key:string]:string} | null = tokenModel.value ? { 'act.account': tokenModel.value.contract } : null;
-                if (actionsModel.value) {
-                    extras = extras ? {
-                        ...extras,
-                        'act.name': actionsModel.value,
-                    } : {
-                        'act.name': actionsModel.value,
-                    };
-                }
-
-                if (page > 1 && currentFirstAction.value === 0) {
-                    currentFirstAction.value = rows.value[0]?.action.global_sequence;
-                }
-
-                if (currentFirstAction.value > 0) {
-                    extras = extras ? {
-                        ...extras,
-                        'global_sequence': '0-' + currentFirstAction.value.toString(),
-                    } : {
-                        'global_sequence': '0-' + currentFirstAction.value.toString(),
-                    };
-                }
-
-                // if token is selected, we need to get all transactions and filter them
-                // so we eventually will need more than the current page size
                 if (tokenModel.value) {
-                    limit = 100;
+                    extras['act.account'] = tokenModel.value.contract;
+                    // Increase limit to allow for filtering
+                    limit = limit * 3;
                 }
+                if (actionsModel.value) {
+                    extras['act.name'] = actionsModel.value;
+                }
+
                 const response = await api.getTransactions({
                     page,
                     limit,
@@ -318,36 +292,42 @@ export default defineComponent({
             if (tableData) {
                 if (tokenModel.value) {
                     tableData = tableData.filter(
-                        item => (item.act.data as {quantity?:string}).quantity?.includes(tokenModel.value.symbol),
+                        item => (item.act.data as {quantity?:string})?.quantity?.includes(tokenModel.value.symbol),
                     );
-
-                    // take only the first aginationSettings.value.rowsPerPage items
-                    tableData = tableData.slice(0, paginationSettings.value.rowsPerPage);
                 }
 
-                rows.value = tableData.map(item => ({
-                    name: item.trx_id,
-                    transaction: { id: item.trx_id, type: 'transaction' },
-                    timestamp: item['@timestamp'] || item.timestamp,
-                    action: item,
-                    data: hasActions.value
-                        ? { data: item.data, name: item.account }
-                        : { data: item.act.data, name: item.act.name },
-                    actions: [
-                        {
-                            name: item.trx_id,
-                            transaction: { id: item.trx_id, type: 'transaction' },
-                            timestamp: item['@timestamp'],
-                            action: item,
-                            data: hasActions.value
-                                ? {
-                                    data: item.data,
-                                    name: item.account,
-                                }
-                                : { data: item.act.data as unknown, name: item.act.name },
-                        },
-                    ],
-                }));
+                const flattenedData: TransactionTableRow[] = [];
+                tableData.forEach((action) => {
+                    const actionsArray = action.act?.data ? [action] : [];
+                    actionsArray.forEach((act) => {
+                        flattenedData.push({
+                            name: act.trx_id,
+                            transaction: { id: act.trx_id, type: 'transaction' },
+                            timestamp: act['@timestamp'] || act.timestamp,
+                            action: act,
+                            data: {
+                                data: act.act.data,
+                                name: act.act.name,
+                            },
+                            actions: actionsArray.map(a => ({
+                                name: a.trx_id,
+                                transaction: { id: a.trx_id, type: 'transaction' },
+                                timestamp: a['@timestamp'] || a.timestamp,
+                                action: a,
+                                data: {
+                                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                                    data: a.act.data,
+                                    name: a.act.name,
+                                },
+                            })),
+                        });
+                    });
+                });
+
+                // Apply pagination after filtering
+                const startIndex = (paginationSettings.value.page - 1) * paginationSettings.value.rowsPerPage;
+                rows.value = flattenedData.slice(startIndex, startIndex + paginationSettings.value.rowsPerPage);
+                totalRows.value = flattenedData.length;
             }
             void filterRows();
         };

--- a/src/pages/Block.vue
+++ b/src/pages/Block.vue
@@ -13,26 +13,51 @@ export default defineComponent({
         const router = useRouter();
         const found = ref(true);
         const block = ref<Block>(null);
+        const block_num = ref<string>(route.params.block as string);
         const actions = ref<Action[]>([]);
         const tab = ref<string>((route.query['tab'] as string) || 'actions');
+        const tries = 3;
+        const error = ref<string>('');
+        // tryToLoadBlock is a function that tries to load a block from the API at least 3 times before giving up
+        const tryToLoadBlock = async (block_num: string) => {
+            error.value = '';
+            let block = null;
+            for (let i = 0; i < tries; i++) {
+                try {
+                    block = await api.getBlock(block_num);
+                    break;
+                } catch (e) {
+                    console.error(`Failed to load block ${block_num} on try ${i + 1}`);
+                    if (i === tries - 1) {
+                        throw e;
+                    }
+                }
+            }
+            return block;
+        };
         onMounted(async () => {
             // api get block and set block
-            block.value = await api.getBlock(route.params.block as string);
-            block.value.transactions.forEach((tr) => {
-                const act = tr.trx.transaction?.actions.map(act => ({
-                    ...act,
-                    trx_id: tr.trx.id,
-                    act: {
-                        ...act.act,
-                        name: act.name,
-                        data: act.data,
-                        account: act.account,
-                    },
-                    '@timestamp': block.value.timestamp,
-                }));
-                actions.value = actions.value.concat(act);
-            });
-            found.value = !!block.value;
+            try {
+                block.value = await tryToLoadBlock(block_num.value);
+                block.value.transactions.forEach((tr) => {
+                    const act = tr.trx.transaction?.actions.map(act => ({
+                        ...act,
+                        trx_id: tr.trx.id,
+                        act: {
+                            ...act.act,
+                            name: act.name,
+                            data: act.data,
+                            account: act.account,
+                        },
+                        '@timestamp': block.value.timestamp,
+                    }));
+                    actions.value = actions.value.concat(act);
+                });
+                found.value = !!block.value;
+            } catch (e) {
+                found.value = false;
+                error.value = 'Unable to load block, try refreshing the page';
+            }
         });
         watch([tab], () => {
             void router.push({
@@ -48,6 +73,8 @@ export default defineComponent({
             found,
             Actions: actions,
             block,
+            block_num,
+            error,
         };
     },
     components: {
@@ -61,7 +88,12 @@ export default defineComponent({
 
 <div class="row">
     <div class="col-12 header-support q-pb-lg">
-        <BlockCard v-if="found" class="q-pa-lg" :block="block"/>
+        <BlockCard
+            v-if="found"
+            class="q-pa-lg"
+            :block="block"
+            :block_num="block_num"
+        />
         <div v-else class="q-pa-lg">
             <div class="row full-width justify-center">
                 <div class="col-xs-12 col-md-8 col-lg-6">
@@ -69,6 +101,9 @@ export default defineComponent({
                         <div class="q-pa-md-md q-pa-sm-sm q-pa-xs-xs q-pa-xl-lg">
                             <q-card-section class="q-pl-md">
                                 <div class="text-h4 text-bold">block not found</div>
+                            </q-card-section>
+                            <q-card-section v-if="error" class="q-pl-md">
+                                <div class="text-h6 text-bold">{{ error }}</div>
                             </q-card-section>
                         </div>
                     </q-card>


### PR DESCRIPTION
# Fixes #860

## Description

Paginates transaction table by actions, since each row is an action that references a transaction, we will show 10 or whatever number selected of rows per page instead of all actions for a single transaction.
## Test scenarios

Verify that block pages are paginating accurately, try blocks around :1289 and newer blocks as well as any blocks you might have knowledge of being special in any way.
Verify filters are working at least as well as in the production release, create a separate issue for any issues found here that are also present in release.

## Checklist:
<!---
You can remove the items that are not relevant for your project.
-->
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have cleaned up the code in the areas my change touches
-   [ ] My changes generate no new warnings
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [ ] I have removed any unnecessary console messages
-   [ ] I have included all english text to the translation file and/or created a new issue with the required translations for the currently supported languages
-   [ ] I have tested for mobile functionality and responsiveness
-   [ ] I have added appropriate test coverage
-   [ ] I have updated relevant documentation and/or opened a separate issue to cover the updates (Issue URL: )
