### PR TITLE
Self stake boost

### DIFF
--- a/src/components/validators/ValidatorDataTable.vue
+++ b/src/components/validators/ValidatorDataTable.vue
@@ -172,7 +172,19 @@ export default defineComponent({
                                 </div>
                             </div>
                             <div class="col-2 q-py-md">
-                                <div class="row items-center full-height">{{ (bp.total_votes / 10000).toLocaleString(undefined, {minimumFractionDigits: 4,maximumFractionDigits: 4,}) }}</div>
+                                <div class="row items-center full-height">
+                                    <div>
+                                        {{ (bp.total_votes / 10000).toLocaleString(undefined, {minimumFractionDigits: 4,maximumFractionDigits: 4,}) }}
+                                        <br>
+                                        <q-chip
+                                            v-if="bp.self_staked_boost > 0"
+                                            color="primary"
+                                            text-color="white"
+                                            :label="`+${(bp.self_staked_boost / 10000).toLocaleString(undefined, {minimumFractionDigits: 4,maximumFractionDigits: 4,})} Boosted`"
+                                            size="sm"
+                                        />
+                                    </div>
+                                </div>
                             </div>
                             <div class="col-2 q-py-md">
                                 <div class="row items-center full-height">{{ ((producerRows.indexOf(bp) + 1) < 22 ? producerPay : (producerRows.indexOf(bp) + 1) < 43 ? producerPay / 2 : 0 ).toFixed(0)  + ` ${symbol}` }}</div>

--- a/src/stores/chain.ts
+++ b/src/stores/chain.ts
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { formatCurrency } from 'src/utils/string-utils';
 import { Chain } from 'src/types/Chain';
 import { getChain } from 'src/config/ConfigManager';
+import { Name } from '@wharfkit/session';
 
 
 export interface ChainStateInterface {
@@ -89,28 +90,44 @@ export const useChainStore = defineStore('chain', {
         ).data as BP[];
                 let producers = (await api.getProducers()).rows;
                 producers = producers.filter(producer => producer.is_active === 1);
-                producers = producers.map((data) => {
+                producers = await Promise.all(producers.map(async (data) => {
                     const bp = producerData.find(
                         producer => producer.owner === data.owner,
                     );
+                    const producerVote = await api.getTableRows({
+                        code: 'eosio',
+                        scope: 'eosio',
+                        table: 'voters',
+                        lower_bound: Name.from(data.owner),
+                        limit: 1,
+                    }) as { rows:  { owner: string; self_stake_boost: number; producers: string[]; last_vote_weight: number }[] };
+                    let selfStakedBoost = 0;
+                    if (producerVote.rows.length > 0 && producerVote.rows[0].owner === data.owner && producerVote.rows[0].self_stake_boost > 0 && producerVote.rows[0].producers.includes(data.owner)) {
+                        selfStakedBoost = (producerVote.rows[0].self_stake_boost / 100) * producerVote.rows[0].last_vote_weight;
+                    }
                     if (bp) {
                         try {
                             return {
                                 ...data,
                                 name: bp.org.candidate_name,
                                 location: bp.org.location.name,
+                                self_staked_boost: selfStakedBoost,
                             };
                         } catch (error) {
-                            return data;
+                            return {
+                                ...data,
+                                self_staked_boost: selfStakedBoost,
+                            };
                         }
                     } else {
                         return {
                             ...data,
                             name: data.owner,
                             location: '',
+                            self_staked_boost: selfStakedBoost,
                         };
                     }
-                });
+                }));
                 producerData.sort((a, b) => b.total_votes - a.total_votes);
                 producers.sort((a, b) => b.total_votes - a.total_votes);
                 this.setProducers(producers);

--- a/src/types/Producers.ts
+++ b/src/types/Producers.ts
@@ -8,4 +8,5 @@ export interface Producer {
   total_votes: number;
   location: string;
   name: string;
+  self_staked_boost: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,10 +2680,10 @@
     "@wharfkit/token" "^1.1.2"
     tslib "^2.1.0"
 
-"@wharfkit/antelope@1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-1.0.10.tgz#5c63d6b67a4b62038575cd86ef47edaa8d1f57dd"
-  integrity sha512-12m4nD6+ZZl+mwzySuFkeiJCOrbXQT6mqg9amr1l/JtRewRdxeN9QTsEoPjE5MCTXbJc84X51KCT71ysglse0Q==
+"@wharfkit/antelope@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@wharfkit/antelope/-/antelope-1.0.13.tgz#216b28da9d9a91ece9db273447f4419aa770657f"
+  integrity sha512-f4O5O8+6Bd5BHpMUHTmlWQmlhX5xYb4AfzT2NJweyqIPqQOstm+aInF42AtUhSALDa8fvoY80YZoqwM0L8TUyw==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
This pull request introduces support for displaying and calculating the "self staked boost" for block producers in the validator data table. The main changes involve updating the producer data model, fetching and computing the new value, and updating the UI to display it when applicable.

**Enhancements to Producer Data Model and Fetching:**

* Added a new `self_staked_boost` field to the `Producer` interface in `src/types/Producers.ts` to store the boost value.
* Modified the producer data fetching logic in `src/stores/chain.ts` to:
  - Query the `voters` table for each producer.
  - Calculate the `self_staked_boost` based on `self_stake_boost` and `last_vote_weight` if applicable.
  - Attach the computed `self_staked_boost` to each producer object.
* Added import for `Name` from `@wharfkit/session` to support querying with the correct type.

**User Interface Improvements:**

* Updated `src/components/validators/ValidatorDataTable.vue` to display a "Boosted" chip with the formatted boost amount under the total votes column when `self_staked_boost` is greater than zero.

<img width="1112" height="679" alt="Screenshot 2025-08-15 180639" src="https://github.com/user-attachments/assets/6c73d256-15c7-45d1-aff4-799904a4db51" />
