### PR TITLE
Scaled BP pay

### DIFF
--- a/src/components/validators/ValidatorDataTable.vue
+++ b/src/components/validators/ValidatorDataTable.vue
@@ -175,7 +175,7 @@ export default defineComponent({
                                 <div class="row items-center full-height">{{ (bp.total_votes / 10000).toLocaleString(undefined, {minimumFractionDigits: 4,maximumFractionDigits: 4,}) }}</div>
                             </div>
                             <div class="col-2 q-py-md">
-                                <div class="row items-center full-height">{{ ((producerRows.indexOf(bp) + 1) < 22 ? producerPay : (producerRows.indexOf(bp) + 1) < 43 ? producerPay / 2 : 0 ).toFixed(0)  + ` ${symbol}` }}</div>
+                                <div class="row items-center full-height">{{ ((producerRows.indexOf(bp) + 1) < 22 ? (producerPay*((120-2*producerRows.indexOf(bp))/100)) : (producerRows.indexOf(bp) + 1) < 43 ? ((producerPay/2)*((162-2*producerRows.indexOf(bp))/100)) : 0 ).toFixed(0)  + ` ${symbol}` }}</div>
                             </div>
                             <div class="col-1 select-box q-py-md">
                                 <div class="row full-selection justify-center">


### PR DESCRIPTION
This pull request updates the logic for calculating and displaying producer pay amounts in the `ValidatorDataTable.vue` component. The change refines the pay calculation to account for a more nuanced formula based on the producer's rank.

Pay calculation improvements:

* Updated the producer pay calculation formula in the rewards column to use a rank-based percentage adjustment, providing a more accurate and granular distribution for top producers. (`src/components/validators/ValidatorDataTable.vue`)