### PR TITLE
Reduce standby bps

### DIFF
--- a/src/components/validators/ValidatorData.vue
+++ b/src/components/validators/ValidatorData.vue
@@ -29,8 +29,8 @@ export default defineComponent({
             () => formatCurrency(lastWeight.value, 2, symbol),
         );
         const activecount = computed(() => {
-            if (chainStore.producers.length > 42) {
-                return 42;
+            if (chainStore.producers.length > 35) {
+                return 35;
             } else {
                 return chainStore.producers.length;
             }
@@ -94,7 +94,7 @@ export default defineComponent({
         }
             ).rows[0].bpay_rate;
             // 2 shares per top 21 bp
-            // 1 share for standby up untill 42 bps
+            // 1 share for standby up until 35 bps
             top21pay24h.value =
         (((payrate.value / 100000) * supply.value) / 365 / sharecount) * 2;
         }

--- a/src/components/validators/ValidatorDataTable.vue
+++ b/src/components/validators/ValidatorDataTable.vue
@@ -154,7 +154,7 @@ export default defineComponent({
                                         label="Top 21"
                                     />
                                     <q-chip
-                                        v-else-if="(producerRows.indexOf(bp) + 1) < 43"
+                                        v-else-if="(producerRows.indexOf(bp) + 1) < 36"
                                         outline
                                         square
                                         color="primary"
@@ -175,7 +175,7 @@ export default defineComponent({
                                 <div class="row items-center full-height">{{ (bp.total_votes / 10000).toLocaleString(undefined, {minimumFractionDigits: 4,maximumFractionDigits: 4,}) }}</div>
                             </div>
                             <div class="col-2 q-py-md">
-                                <div class="row items-center full-height">{{ ((producerRows.indexOf(bp) + 1) < 22 ? (producerPay*((120-2*producerRows.indexOf(bp))/100)) : (producerRows.indexOf(bp) + 1) < 43 ? ((producerPay/2)*((162-2*producerRows.indexOf(bp))/100)) : 0 ).toFixed(0)  + ` ${symbol}` }}</div>
+                                <div class="row items-center full-height">{{ ((producerRows.indexOf(bp) + 1) < 22 ? (producerPay*((120-2*producerRows.indexOf(bp))/100)) : (producerRows.indexOf(bp) + 1) < 36 ? ((producerPay/2)*((162-2*producerRows.indexOf(bp))/100)) : 0 ).toFixed(0)  + ` ${symbol}` }}</div>
                             </div>
                             <div class="col-1 select-box q-py-md">
                                 <div class="row full-selection justify-center">


### PR DESCRIPTION
DON'T MERGE UNTIL #884 IS MERGED

This pull request updates the logic and display thresholds for standby block producers in the validator components, reducing the range from 21 to 14. This change affects how standby producers are counted, labeled, and paid in both the `ValidatorData.vue` and `ValidatorDataTable.vue` components.