### PR TITLE
fix: correct vote weight display units in ValidatorData card

### DIFF
--- a/src/components/validators/ValidatorData.vue
+++ b/src/components/validators/ValidatorData.vue
@@ -26,7 +26,7 @@ export default defineComponent({
         const symbol = chain.getSystemToken().symbol;
         const account = computed(() => accountStore.accountName);
         const balance = computed(
-            () => formatCurrency(lastWeight.value, 2, symbol),
+            () => formatCurrency(lastWeight.value / 10000, 2, symbol),
         );
         const activecount = computed(() => {
             if (chainStore.producers.length > 35) {


### PR DESCRIPTION
The 'Current Vote Weight' card displays `last_vote_weight` from the voters table without dividing by 10000, inflating the displayed number by 10,000x.

**Example (TelosIndiaBP):**
- Shows: `822,059.37 TLOS`
- Actual: `82.2 TLOS` vote weight

This also caused visual confusion with the self-stake boost chip, which correctly divides by 10000 — making the boost appear 1000x smaller than the displayed vote weight.

**Fix:** Add `/ 10000` to the balance computation in ValidatorData.